### PR TITLE
Remove debug print

### DIFF
--- a/worker/frame_notify.go
+++ b/worker/frame_notify.go
@@ -48,6 +48,4 @@ func (w *worker) processNotifyFrame(f *frame.Frame) {
 	if n != buf.Len() {
 		log.Printf("write wrong data count %d, expect %d", n, buf.Len())
 	}
-
-	log.Printf("[DEBUG] write %d bytes ack frame", buf.Len())
 }


### PR DESCRIPTION
I don't think this always needs to be printed but I could also see moving to a logger like glog or logrus to be able to set a log level and print at debug.