### PR TITLE
Fix a race condition in worker

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v1
       - name: Test
-        run: go test ./...
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+.PHONY: setup
+setup: ## Install all the build and lint dependencies
+	go get -u golang.org/x/tools/cmd/cover
+
+.PHONY: test
+test: ## Run all the tests
+	echo 'mode: atomic' > coverage.txt && go test -covermode=atomic -coverpkg=./... -coverprofile=coverage.txt -race -timeout=30s ./...
+
+.PHONY: cover
+cover: test ## Run all the tests and opens the coverage report
+	go tool cover -html=coverage.txt
+
+.PHONY: fmt
+fmt: ## Run goimports on all go files
+	find . -name '*.go' -not -wholename './vendor/*' | while read -r file; do goimports -w "$$file"; done
+
+.PHONY: ci
+ci: test ## Run all the tests and code checks
+
+.PHONY: build
+build: ## Build a version
+	go build -v ./...
+
+.PHONY: clean
+clean: ## Remove temporary files
+	go clean
+
+# Absolutely awesome: http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+.PHONY: help
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.DEFAULT_GOAL := build

--- a/client/client.go
+++ b/client/client.go
@@ -1,0 +1,101 @@
+package client
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"github.com/negasus/haproxy-spoe-go/frame"
+	_ "github.com/negasus/haproxy-spoe-go/request"
+	"io"
+	"net"
+)
+
+type Client struct {
+	conn   net.Conn
+	reader io.Reader
+}
+
+func NewClient(conn net.Conn) Client {
+	return Client{conn: conn, reader: bufio.NewReader(conn)}
+}
+
+func (c *Client) Init() error {
+	f := frame.AcquireFrame()
+	defer frame.ReleaseFrame(f)
+	f.Type = frame.TypeHaproxyHello
+	f.StreamID = 0
+	f.FrameID = 0
+	f.KV.Add("supported-versions", "2")
+	f.KV.Add("max-frame-size", uint32(16*1024))
+	f.KV.Add("capabilities", "pipelining")
+
+	err := c.send(f)
+	if err != nil {
+		return err
+	}
+
+	responseFrame := frame.AcquireFrame()
+	defer frame.ReleaseFrame(responseFrame)
+	responseFrame.Read(c.reader)
+	// todo read frame
+
+	return nil
+
+}
+
+func (c *Client) send(f *frame.Frame) error {
+	buf := bytes.NewBuffer(make([]byte, 0))
+	n, err := f.Encode(buf)
+	if err != nil {
+		return err
+	}
+	n, err = c.conn.Write(buf.Bytes())
+	if err != nil {
+		return err
+	}
+	if n != buf.Len() {
+		return fmt.Errorf("size mismatch")
+	}
+	return nil
+}
+
+func (c *Client) Notify() error {
+	f := frame.AcquireFrame()
+	defer frame.ReleaseFrame(f)
+	f.Type = frame.TypeNotify
+	f.StreamID = 1
+	f.FrameID = 1
+
+	err := c.send(f)
+	if err != nil {
+		return err
+	}
+
+	responseFrame := frame.AcquireFrame()
+	defer frame.ReleaseFrame(responseFrame)
+	responseFrame.Read(c.reader)
+
+	return nil
+
+}
+func (c *Client) Stop() error {
+	f := frame.AcquireFrame()
+	defer frame.ReleaseFrame(f)
+	f.Type = frame.TypeHaproxyDisconnect
+	f.StreamID = 0
+	f.FrameID = 0
+	f.KV.Add("status-code", uint32(0))
+	f.KV.Add("message", "normal")
+
+	err := c.send(f)
+	if err != nil {
+		return err
+	}
+
+	responseFrame := frame.AcquireFrame()
+	defer frame.ReleaseFrame(responseFrame)
+	responseFrame.Read(c.reader)
+
+	return nil
+
+}

--- a/client/client.go
+++ b/client/client.go
@@ -27,7 +27,7 @@ func (c *Client) Init() error {
 	f.FrameID = 0
 	f.KV.Add("supported-versions", "2")
 	f.KV.Add("max-frame-size", uint32(16*1024))
-	f.KV.Add("capabilities", "pipelining")
+	f.KV.Add("capabilities", "")
 
 	err := c.send(f)
 	if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -10,15 +10,18 @@ import (
 	"net"
 )
 
+/// Client is a simple client for spop protocol, this should only be used for testing purpose
 type Client struct {
 	conn   net.Conn
 	reader io.Reader
 }
 
+/// NewClient create a new Client for an established connection
 func NewClient(conn net.Conn) Client {
 	return Client{conn: conn, reader: bufio.NewReader(conn)}
 }
 
+/// Init initialize the client by sending the HaproxyHello frame
 func (c *Client) Init() error {
 	f := frame.AcquireFrame()
 	defer frame.ReleaseFrame(f)
@@ -59,6 +62,7 @@ func (c *Client) send(f *frame.Frame) error {
 	return nil
 }
 
+/// Notify send an empty Notify frame
 func (c *Client) Notify() error {
 	f := frame.AcquireFrame()
 	defer frame.ReleaseFrame(f)
@@ -74,10 +78,10 @@ func (c *Client) Notify() error {
 	responseFrame := frame.AcquireFrame()
 	defer frame.ReleaseFrame(responseFrame)
 	responseFrame.Read(c.reader)
-
 	return nil
-
 }
+
+/// Stop the client by sending HaproxyDisconnect frame
 func (c *Client) Stop() error {
 	f := frame.AcquireFrame()
 	defer frame.ReleaseFrame(f)

--- a/client/client.go
+++ b/client/client.go
@@ -40,7 +40,15 @@ func (c *Client) Init() error {
 	responseFrame := frame.AcquireFrame()
 	defer frame.ReleaseFrame(responseFrame)
 	responseFrame.Read(c.reader)
-	// todo read frame
+
+	switch responseFrame.Type {
+	case frame.TypeAgentHello:
+		if responseFrame.FrameID != uint64(0) || responseFrame.StreamID != uint64(0) {
+			return fmt.Errorf("FrameID or StreamID mismatch")
+		}
+	default:
+		return fmt.Errorf("unexpected frame type: %v", responseFrame.Type)
+	}
 
 	return nil
 

--- a/frame/encode.go
+++ b/frame/encode.go
@@ -34,10 +34,12 @@ func (f *Frame) Encode(dest io.Writer) (n int, err error) {
 		}
 
 	case TypeAgentAck:
-		for _, act := range *f.Actions {
-			payload, err = (*act).Marshal(payload)
-			if err != nil {
-				return
+		if f.Actions != nil {
+			for _, act := range *f.Actions {
+				payload, err = (*act).Marshal(payload)
+				if err != nil {
+					return
+				}
 			}
 		}
 	case TypeNotify:

--- a/frame/encode.go
+++ b/frame/encode.go
@@ -27,7 +27,7 @@ func (f *Frame) Encode(dest io.Writer) (n int, err error) {
 	var payload []byte
 
 	switch f.Type {
-	case TypeAgentHello, TypeAgentDisconnect:
+	case TypeAgentHello, TypeAgentDisconnect, TypeHaproxyHello, TypeHaproxyDisconnect:
 		payload, err = f.KV.Bytes()
 		if err != nil {
 			return
@@ -40,7 +40,8 @@ func (f *Frame) Encode(dest io.Writer) (n int, err error) {
 				return
 			}
 		}
-
+	case TypeNotify:
+		//todo marshal messages
 	default:
 		err = fmt.Errorf("unexpected frame type %d", f.Type)
 		return

--- a/frame/encode.go
+++ b/frame/encode.go
@@ -41,7 +41,11 @@ func (f *Frame) Encode(dest io.Writer) (n int, err error) {
 			}
 		}
 	case TypeNotify:
-		//todo marshal messages
+		if len(*f.Messages) > 0 {
+			err = fmt.Errorf("Encoding Notify frame with Message isn't handled yet")
+			return
+
+		}
 	default:
 		err = fmt.Errorf("unexpected frame type %d", f.Type)
 		return

--- a/frame/frame.go
+++ b/frame/frame.go
@@ -59,7 +59,6 @@ func NewFrame() *Frame {
 		Flags:     0x01,
 		KV:        kv.AcquireKV(),
 		Messages:  message.NewMessages(),
-		Actions:   action.NewActions(),
 		tmp:       make([]byte, 4),
 		varintBuf: make([]byte, 10),
 	}
@@ -77,8 +76,7 @@ func (f *Frame) Reset() {
 	f.Healthcheck = false
 	f.MaxFrameSize = 0
 
-	// we want to acquire a new Actions as they are shared with Request
-	f.Actions = action.NewActions()
+	f.Actions = nil
 	f.Messages.Reset()
 	f.KV.Reset()
 }

--- a/frame/frame.go
+++ b/frame/frame.go
@@ -77,7 +77,8 @@ func (f *Frame) Reset() {
 	f.Healthcheck = false
 	f.MaxFrameSize = 0
 
-	f.Actions.Reset()
+	// we want to acquire a new Actions as they are shared with Request
+	f.Actions = action.NewActions()
 	f.Messages.Reset()
 	f.KV.Reset()
 }

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -1,0 +1,49 @@
+package worker
+
+import (
+	"fmt"
+	"github.com/negasus/haproxy-spoe-go/client"
+	"github.com/negasus/haproxy-spoe-go/request"
+	"github.com/stretchr/testify/assert"
+	_ "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"net"
+	"testing"
+	"time"
+)
+
+type MockedHandler struct {
+	m mock.Mock
+}
+
+func (h *MockedHandler) Handle(r *request.Request) {
+	h.m.MethodCalled("handle", r)
+	fmt.Println("test")
+}
+
+func (h *MockedHandler) Finish() {
+	h.m.MethodCalled("Finished")
+}
+
+func TestWorker(t *testing.T) {
+	clientConn, server := net.Pipe()
+	spoe := client.NewClient(clientConn)
+	var m MockedHandler
+	m.m.On("handle", mock.Anything)
+	m.m.On("Finished")
+
+	go func() {
+		Handle(server, m.Handle)
+		m.Finish()
+	}()
+	assert.NoError(t, spoe.Init())
+	assert.NoError(t, spoe.Notify())
+	assert.NoError(t, spoe.Stop())
+
+	// Lets wait a bit to have everything finished
+	<-time.After(time.Millisecond * 100)
+	clientConn.Close()
+
+	m.m.AssertExpectations(t)
+
+}

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -65,7 +65,6 @@ func TestWorkerConcurrent(t *testing.T) {
 		Handle(server2, m.Handle)
 	}()
 	duration := time.Second
-	assert.NoError(t, spoe2.Init())
 	loop := func(s client.Client) {
 		assert.NoError(t, s.Init())
 		for {


### PR DESCRIPTION
This is quite a big PR, but we wanted to add a test that emphasize the problems.

So This PR add a `Client` to be used for tests, it implements a very basic SPOP client. This `Client` is used to test the worker, there is currently two tests:
  - a basic test that only send one request
  - a second test that start two goroutine that will do queries for 1 seconds. Before the fix this test was failing.

The actual fix (https://github.com/negasus/haproxy-spoe-go/commit/e5b304b578a24c1712372f3ae4465f3af7198954) is quite easy, a `Request` and a `Frame` can reference the same `Actions` (https://github.com/negasus/haproxy-spoe-go/blob/master/worker/frame_notify.go#L33) and later be used concurrently and causing UB.
I now create a new `Actions` in `Frame.Reset()`, this as the disadvantage of reducing the use of the associated `Pool`, if you have a better idea I can change it.

The error trace was:
```
WARNING: DATA RACE
Read at 0x00c0002f27a0 by goroutine 57:
  github.com/negasus/haproxy-spoe-go/action.(*Actions).Reset()
      /home/kinou/workspace/other/haproxy-spoe-go/action/actions.go:18 +0x56
  github.com/negasus/haproxy-spoe-go/request.(*Request).Reset()
      /home/kinou/workspace/other/haproxy-spoe-go/request/request.go:49 +0x90
  github.com/negasus/haproxy-spoe-go/request.ReleaseRequest()
      /home/kinou/workspace/other/haproxy-spoe-go/request/request.go:42 +0x50
  github.com/negasus/haproxy-spoe-go/worker.(*worker).processNotifyFrame()
      /home/kinou/workspace/other/haproxy-spoe-go/worker/frame_notify.go:51 +0x7c8

Previous write at 0x00c0002f27a0 by goroutine 16:
  github.com/negasus/haproxy-spoe-go/action.(*Actions).Reset()
      /home/kinou/workspace/other/haproxy-spoe-go/action/actions.go:22 +0x10c
  github.com/negasus/haproxy-spoe-go/frame.(*Frame).Reset()
      /home/kinou/workspace/other/haproxy-spoe-go/frame/frame.go:81 +0x146
  github.com/negasus/haproxy-spoe-go/frame.ReleaseFrame()
      /home/kinou/workspace/other/haproxy-spoe-go/frame/frame.go:33 +0x50
  github.com/negasus/haproxy-spoe-go/client.(*Client).Notify()
      /home/kinou/workspace/other/haproxy-spoe-go/client/client.go:81 +0x1d0
  github.com/negasus/haproxy-spoe-go/worker.TestWorkerConcurrent.func3()
      /home/kinou/workspace/other/haproxy-spoe-go/worker/worker_test.go:75 +0xf9

Goroutine 57 (running) created at:
  github.com/negasus/haproxy-spoe-go/worker.(*worker).run()
      /home/kinou/workspace/other/haproxy-spoe-go/worker/worker.go:98 +0x25b
  github.com/negasus/haproxy-spoe-go/worker.Handle()
      /home/kinou/workspace/other/haproxy-spoe-go/worker/worker.go:24 +0xf4
  github.com/negasus/haproxy-spoe-go/worker.TestWorkerConcurrent.func2()
      /home/kinou/workspace/other/haproxy-spoe-go/worker/worker_test.go:65 +0xa6

Goroutine 16 (running) created at:
  github.com/negasus/haproxy-spoe-go/worker.TestWorkerConcurrent()
      /home/kinou/workspace/other/haproxy-spoe-go/worker/worker_test.go:80 +0x3a3
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:909 +0x199
==================
```
I also added a `Makefile` to ease test running as there are some options, I can remove it if you don't like makefile :) 