### PR TITLE
Add bench test for mem and fix memory issue

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -45,10 +45,10 @@ func (w *worker) run() error {
 
 	var f *frame.Frame
 
+	buf := bufio.NewReader(w.conn)
+
 	for {
 		f = frame.AcquireFrame()
-
-		buf := bufio.NewReader(w.conn)
 
 		if err := f.Read(buf); err != nil {
 			frame.ReleaseFrame(f)


### PR DESCRIPTION
Hi,
This PR goes with PR #4. It does the following:

- Add a bench using the client to exhibit memory issue we discovered

- A fix for the aforementioned issue that moves the bufio reader outside of for loop so that It can be reused in subsequent calls

Before change
```
go test -run=^\$ -v -bench=BenchmarkWorker ./worker -benchmem -memprofile profile1
goos: linux
goarch: amd64
pkg: github.com/negasus/haproxy-spoe-go/worker
BenchmarkWorker-4          11499             87698 ns/op            8301 B/op         65 allocs/op
PASS
ok      github.com/negasus/haproxy-spoe-go/worker       2.272s
``` 

After the change
```
go test -run=^\$ -v -bench=BenchmarkWorker ./worker -benchmem -memprofile profile2
goos: linux
goarch: amd64
pkg: github.com/negasus/haproxy-spoe-go/worker
BenchmarkWorker-4          15517             77268 ns/op            4046 B/op         63 allocs/op
PASS
ok      github.com/negasus/haproxy-spoe-go/worker       2.347s
```

This PR  brings changes already submitted, the commits to review are the following:

1. adcf463

1. 0ebbda0 
