### PR TITLE
Fix random error under load

### DIFF
--- a/frame/read.go
+++ b/frame/read.go
@@ -11,7 +11,7 @@ func (f *Frame) Read(src io.Reader) error {
 	var n int
 	var err error
 
-	n, err = src.Read(f.tmp)
+	n, err = io.ReadFull(src, f.tmp)
 	if err != nil {
 		if err == io.EOF {
 			return err


### PR DESCRIPTION
Replace `Read` by `io.ReadFull` as read may not return a complete buffer
as stated in the [documentation](https://golang.org/pkg/bufio/#Reader.Read):
> the bytes are taken from at most one Read on the underlying Reader, hence n may be less than len(p)

We only had this kind error under load, like thousands of requests per
seconds.

The panic looks like this:
```
panic: runtime error: index out of range [0] with length 0

goroutine 1974352 [running]:
github.com/negasus/haproxy-spoe-go/frame.(*Frame).Read(0xc000916900, 0xa4ae40, 0xc000c103c0, 0xc000916880, 0x0)
  /go/pkg/mod/github.com/!adikteev/haproxy-spoe-go@v1.0.1-0.20200217162005-dcbc6d1023b1/frame/read.go:35 +0x78b
github.com/negasus/haproxy-spoe-go/worker.(*worker).run(0xc000cc85a0, 0x0, 0x0)
  /go/pkg/mod/github.com/!adikteev/haproxy-spoe-go@v1.0.1-0.20200217162005-dcbc6d1023b1/worker/worker.go:53 +0x13b
github.com/negasus/haproxy-spoe-go/worker.Handle(0xa5a940, 0xc0005b6040, 0xc000232150)
  /go/pkg/mod/github.com/!adikteev/haproxy-spoe-go@v1.0.1-0.20200217162005-dcbc6d1023b1/worker/worker.go:24 +0x66
created by github.com/negasus/haproxy-spoe-go/agent.(*Agent).Serve
  /go/pkg/mod/github.com/!adikteev/haproxy-spoe-go@v1.0.1-0.20200217162005-dcbc6d1023b1/agent/agent.go:31 +0xe7
```