### PR TITLE
Fix oom on http requests

### DIFF
--- a/frame/encode_test.go
+++ b/frame/encode_test.go
@@ -1,0 +1,44 @@
+package frame
+
+import (
+	"bytes"
+	"encoding/binary"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestFrame_Write(t *testing.T) {
+	f := NewFrame()
+	f.Type = TypeAgentDisconnect
+	f.FrameID = 123
+	f.StreamID = 456
+	f.KV.Add("key1", "val1")
+	f.KV.Add("key2", "val2")
+	buf := &bytes.Buffer{}
+	frameSize, err := f.Encode(buf)
+	require.Nil(t, err)
+	bufBytes := buf.Bytes()
+	encodedFrameSize := int(binary.BigEndian.Uint32(bufBytes[0:4]))
+	assert.Equal(t, frameSize-4, encodedFrameSize, "frame size")
+	assert.Equal(t, "key1", string(bufBytes[13:17]))
+	assert.Equal(t, "val1", string(bufBytes[19:23]))
+	assert.Equal(t, "key2", string(bufBytes[24:28]))
+	assert.Equal(t, "val2", string(bufBytes[30:34]))
+
+}
+
+func BenchmarkFrame_Encode(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		f := NewFrame()
+		f.Type = TypeAgentDisconnect
+		f.FrameID = 123
+		f.StreamID = 456
+		f.KV.Add("key1", "val1")
+		f.KV.Add("key2", "val2")
+		buf := &bytes.Buffer{}
+		_, _ = f.Encode(buf)
+	}
+}

--- a/frame/frame.go
+++ b/frame/frame.go
@@ -48,19 +48,17 @@ type Frame struct {
 	Messages     *message.Messages
 	Actions      *action.Actions
 
-	tmp       []byte
-	varintBuf []byte
+	tmp       [5]byte
+	varintBuf [10]byte
 }
 
 // NewFrame creates and returns new Frame
 // Fin byte in Flags already set
 func NewFrame() *Frame {
 	f := &Frame{
-		Flags:     0x01,
-		KV:        kv.AcquireKV(),
-		Messages:  message.NewMessages(),
-		tmp:       make([]byte, 4),
-		varintBuf: make([]byte, 10),
+		Flags:    0x01,
+		KV:       kv.AcquireKV(),
+		Messages: message.NewMessages(),
 	}
 
 	return f

--- a/frame/read_test.go
+++ b/frame/read_test.go
@@ -1,0 +1,54 @@
+package frame
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io"
+	"testing"
+)
+
+var testFrame = []byte(string(
+	"\x00\x00\x00\x53" + // Size
+		"\x03" + //TypeNotify
+		"\x00\x00\x00\x01\xfe\x12\x01\x11\x67\x65\x74" +
+		"\x2d\x69\x70\x2d\x72\x65\x70\x75\x74\x61\x74\x69\x6f\x6e\x04\x02" +
+		"\x69\x70\x06\xc1\xc8\xe3\xde\x04" +
+		"host" + //Host
+		"\x08\x12" +
+		"domain.example.com" + // authtest.ninjas.pl
+		"\x0d\x61\x75\x74\x68\x6f\x72\x69\x7a\x61\x74\x69\x6f\x6e\x00\x06" +
+		"\x63\x6f\x6f\x6b\x69\x65\x00",
+))
+
+func TestFrame_Read(t *testing.T) {
+	r := bytes.NewBuffer(testFrame)
+	f := NewFrame()
+	err := f.Read(r)
+	require.Nil(t, err)
+	assert.Equal(t, 1, int(f.FrameID), "FrameID")
+	assert.Equal(t, 542, int(f.StreamID), "StreamID")
+	assert.Equal(t, TypeNotify, f.Type)
+	messages := *f.Messages
+	require.Len(t, messages, 1)
+	host, found := messages[0].KV.Get("host")
+	require.True(t, found, "key host")
+	hostString, ok := host.(string)
+	require.True(t, ok)
+	assert.Equal(t, "domain.example.com", hostString)
+}
+
+func BenchmarkFrame_Read(b *testing.B) {
+	readers := make([]io.Reader, b.N)
+	// prepare readers beforehand, so we don't measure the performance of NewReader
+	for idx := range readers {
+		readers[idx] = bytes.NewBuffer(testFrame)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		f := NewFrame()
+		_ = f.Read(readers[i])
+	}
+
+}


### PR DESCRIPTION
Hi, 

during testing I've encountered an interesting problem. By accident I had my haproxy SPOE backend send to do HTTP checks, and it turns out due the way it is decoded that is enough for the lib to take gobs of memory:
```
(pprof) top
Showing nodes accounting for 1.11GB, 99.91% of 1.11GB total
Dropped 16 nodes (cum <= 0.01GB)
      flat  flat%   sum%        cum   cum%
    1.11GB 99.91% 99.91%     1.11GB 99.91%  github.com/negasus/haproxy-spoe-go/frame.(*Frame).Read
         0     0% 99.91%     1.11GB 99.91%  github.com/negasus/haproxy-spoe-go/worker.(*worker).run
         0     0% 99.91%     1.11GB 99.91%  github.com/negasus/haproxy-spoe-go/worker.Handle
```
That's effect of the decoder getting `GET ` in first 4 bytes and interpreting it as size, then making the big buffer and reading everything after that into it. Just `curl`ing on the port is enough to reproduce it.

I was wondering how that could be fixed, currently spurious request (from vulnerability scanner we run, or just from admin typing curl http://localhost:port ) can pretty easily OOM the app using the lib.

The patch is adding checking type of the message before allocating buffer so at the very least not everything will break it. I've also replaced temporary slices with arrays to get back a bit of performance lost by that extra checking and added some tests to make sure I didn't broke something

However I'm wondering if it would make sense to have message size limit set in addition, or instead of that. While the protocol spec doesn't say what max frame size should be, by default HAProxy won't send packet bigger than few KBs (default is tune.bufsize-4  so 16kB), so having say a megabyte as upper boundary would at least avoid the potential of app OOMing the second something sends some bad data to the socket.