### PR TITLE
feat: support for decoding IPv6 addresses

### DIFF
--- a/typeddata/typeddata.go
+++ b/typeddata/typeddata.go
@@ -168,6 +168,11 @@ func Decode(buf []byte) (data interface{}, n int, err error) {
 		n += 4
 		return
 
+	case TypeIPv6:
+		data = net.IP(buf[:16])
+		n += 16
+		return
+
 	case TypeString:
 		sLen, i := varint.Uvarint(buf)
 		n += i


### PR DESCRIPTION
`TypeIPv6` is not implemented in typeddata.go.

This PR adds support for parsing IPv6 addresses.