### PR TITLE
Introduce generic logger interface

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1,14 +1,17 @@
 package agent
 
 import (
+	"net"
+
+	"github.com/negasus/haproxy-spoe-go/logger"
 	"github.com/negasus/haproxy-spoe-go/request"
 	"github.com/negasus/haproxy-spoe-go/worker"
-	"net"
 )
 
-func New(handler func(*request.Request)) *Agent {
+func New(handler func(*request.Request), logger logger.Logger) *Agent {
 	agent := &Agent{
 		handler: handler,
+		logger:  logger,
 	}
 
 	return agent
@@ -16,6 +19,7 @@ func New(handler func(*request.Request)) *Agent {
 
 type Agent struct {
 	handler func(*request.Request)
+	logger  logger.Logger
 }
 
 func (agent *Agent) Serve(listener net.Listener) error {
@@ -28,6 +32,6 @@ func (agent *Agent) Serve(listener net.Listener) error {
 			return err
 		}
 
-		go worker.Handle(conn, agent.handler)
+		go worker.Handle(conn, agent.handler, agent.logger)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/negasus/haproxy-spoe-go
 
-go 1.12
+go 1.13
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/logger/channel.go
+++ b/logger/channel.go
@@ -1,0 +1,33 @@
+package logger
+
+var _ Logger = Channel{}
+
+// LogMessage represents a single log message to be logger.
+//
+// This structure groups parameters of a single log line to allow sending them
+// over a channel.
+type LogMessage struct {
+	format string
+	args   []interface{}
+}
+
+// Channel is Logger sensing messages to be logged over a channel.
+type Channel struct {
+	ch chan<- LogMessage
+}
+
+// NewChannel creates a new Channel Logger logging to ch.
+//
+// WARNING: If the channel gets full, the write of log message will block.
+// Consequently, it's absolutely necessary to provide a channel with sufficient
+// capacity and to guarantee that messages from it are consumed.
+func NewChannel(ch chan<- LogMessage) Channel {
+	return Channel{ch: ch}
+}
+
+func (c Channel) Errorf(format string, args ...interface{}) {
+	c.ch <- LogMessage{
+		format: format,
+		args:   args,
+	}
+}

--- a/logger/log.go
+++ b/logger/log.go
@@ -1,0 +1,28 @@
+package logger
+
+import "log"
+
+var _ Logger = &Log{}
+
+// defaultLog is singleton representing default logger of Go log package.
+var defaultLog = NewLog(log.Default())
+
+// Log is Logger using standard logger provided by Go standard log package.
+type Log struct {
+	l *log.Logger
+}
+
+// NewLog creates new Log using l for logging.
+func NewLog(l *log.Logger) *Log { return &Log{l: l} }
+
+// NewDefaultLog returns instance of Log using default logger of Go standard log
+// package.
+func NewDefaultLog() *Log { return defaultLog }
+
+func (l *Log) Errorf(format string, args ...interface{}) {
+	l.l.Printf("error: "+format, args...)
+}
+
+func (l *Log) Warnf(format string, args ...interface{}) {
+	l.l.Printf("warning: "+format, args...)
+}

--- a/logger/log.go
+++ b/logger/log.go
@@ -16,15 +16,9 @@ func (l *Log) Errorf(format string, args ...interface{}) {
 	l.l.Printf("error: "+format, args...)
 }
 
-func (l *Log) Warnf(format string, args ...interface{}) {
-	l.l.Printf("warning: "+format, args...)
-}
-
 // Log is Logger using default standard logger provided by Go standard log
 // package.
-type DefaultLog struct {
-	l *log.Logger
-}
+type DefaultLog struct{}
 
 // defaultLog is singleton representing default logger of Go log package.
 var defaultLog = &DefaultLog{}
@@ -35,8 +29,4 @@ func NewDefaultLog() *DefaultLog { return defaultLog }
 
 func (*DefaultLog) Errorf(format string, args ...interface{}) {
 	log.Printf("error: "+format, args...)
-}
-
-func (*DefaultLog) Warnf(format string, args ...interface{}) {
-	log.Printf("warning: "+format, args...)
 }

--- a/logger/log.go
+++ b/logger/log.go
@@ -4,9 +4,6 @@ import "log"
 
 var _ Logger = &Log{}
 
-// defaultLog is singleton representing default logger of Go log package.
-var defaultLog = NewLog(log.Default())
-
 // Log is Logger using standard logger provided by Go standard log package.
 type Log struct {
 	l *log.Logger
@@ -15,14 +12,31 @@ type Log struct {
 // NewLog creates new Log using l for logging.
 func NewLog(l *log.Logger) *Log { return &Log{l: l} }
 
-// NewDefaultLog returns instance of Log using default logger of Go standard log
-// package.
-func NewDefaultLog() *Log { return defaultLog }
-
 func (l *Log) Errorf(format string, args ...interface{}) {
 	l.l.Printf("error: "+format, args...)
 }
 
 func (l *Log) Warnf(format string, args ...interface{}) {
 	l.l.Printf("warning: "+format, args...)
+}
+
+// Log is Logger using default standard logger provided by Go standard log
+// package.
+type DefaultLog struct {
+	l *log.Logger
+}
+
+// defaultLog is singleton representing default logger of Go log package.
+var defaultLog = &DefaultLog{}
+
+// NewDefaultLog returns instance of Log using default logger of Go standard log
+// package.
+func NewDefaultLog() *DefaultLog { return defaultLog }
+
+func (*DefaultLog) Errorf(format string, args ...interface{}) {
+	log.Printf("error: "+format, args...)
+}
+
+func (*DefaultLog) Warnf(format string, args ...interface{}) {
+	log.Printf("warning: "+format, args...)
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -3,5 +3,4 @@ package logger
 // Logger is any object with ability to log internal errors and warnings.
 type Logger interface {
 	Errorf(format string, args ...interface{})
-	Warnf(format string, args ...interface{})
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,7 @@
+package logger
+
+// Logger is any object with ability to log internal errors and warnings.
+type Logger interface {
+	Errorf(format string, args ...interface{})
+	Warnf(format string, args ...interface{})
+}

--- a/logger/nop.go
+++ b/logger/nop.go
@@ -11,4 +11,3 @@ type Nop struct{}
 func NewNop() *Nop { return nop }
 
 func (*Nop) Errorf(_ string, _ ...interface{}) {}
-func (*Nop) Warnf(_ string, _ ...interface{})  {}

--- a/logger/nop.go
+++ b/logger/nop.go
@@ -1,0 +1,14 @@
+package logger
+
+var _ Logger = &Nop{}
+
+var nop = &Nop{}
+
+// Nop is Logger implementation which never logs.
+type Nop struct{}
+
+// NewNop returns a Nop logger.
+func NewNop() *Nop { return nop }
+
+func (*Nop) Errorf(_ string, _ ...interface{}) {}
+func (*Nop) Warnf(_ string, _ ...interface{})  {}

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Haproxy SPOE Golang Agent Library [![Go Report Card](https://goreportcard.com/badge/github.com/negasus/haproxy-spoe-go)](https://goreportcard.com/report/github.com/negasus/haproxy-spoe-go) ![](https://github.com/negasus/haproxy-spoe-go/workflows/Test/badge.svg)
 
-Terms from [Haproxy SPOE specification](https://www.haproxy.org/download/1.9/doc/SPOE.txt) 
+Terms from [Haproxy SPOE specification](https://www.haproxy.org/download/1.9/doc/SPOE.txt)
 
 ```
 * SPOE : Stream Processing Offload Engine.
@@ -42,7 +42,7 @@ Example from Section 2.5 [SPOE specification](https://www.haproxy.org/download/1
   and 0 a blacklisted IP with no doubt).
 
 Golang backend application for this example
- 
+
 ```go
 package main
 
@@ -50,6 +50,7 @@ import (
 	"github.com/negasus/haproxy-spoe-go/action"
 	"github.com/negasus/haproxy-spoe-go/agent"
 	"github.com/negasus/haproxy-spoe-go/request"
+        logger "github.com/negasus/haproxy-spoe-go/log"
 	"log"
 	"math/rand"
 	"net"
@@ -67,7 +68,7 @@ func main() {
 	}
 	defer listener.Close()
 
-	a := agent.New(handler)
+	a := agent.New(handler, logger.NewDefaultLog())
 
 	if err := a.Serve(listener); err != nil {
 		log.Printf("error agent serve: %+v\n", err)
@@ -117,7 +118,7 @@ Getting request data is possible through `Request.Messages`
 Returns count of messages in request
 
 ```
-count := request.Messages.Len() 
+count := request.Messages.Len()
 ```
 
 #### GetByName(name string) (*Message, error)
@@ -175,7 +176,7 @@ request.Actions.UnsetVar(action.ScopeSession, "ip_score")
 
 ### KV (key-value)
 
-Contains message key-value data sent by Haproxy 
+Contains message key-value data sent by Haproxy
 
 #### Get(key string) (interface{}, bool)
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -103,7 +103,7 @@ func (w *worker) run() error {
 			go w.processNotifyFrame(f)
 
 		default:
-			w.logger.Warnf("unexpected frame type: %v", f.Type)
+			w.logger.Errorf("unexpected frame type: %v", f.Type)
 		}
 	}
 }

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -1,14 +1,16 @@
 package worker
 
 import (
+	"net"
+	"testing"
+	"time"
+
 	"github.com/negasus/haproxy-spoe-go/client"
+	"github.com/negasus/haproxy-spoe-go/logger"
 	"github.com/negasus/haproxy-spoe-go/request"
 	"github.com/stretchr/testify/assert"
 	_ "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"net"
-	"testing"
-	"time"
 )
 
 type MockedHandler struct {
@@ -31,7 +33,7 @@ func TestWorker(t *testing.T) {
 	m.m.On("Finished")
 
 	go func() {
-		Handle(server, m.Handle)
+		Handle(server, m.Handle, logger.NewNop())
 		m.Finish()
 	}()
 	assert.NoError(t, spoe.Init())
@@ -59,10 +61,10 @@ func TestWorkerConcurrent(t *testing.T) {
 	m.m.On("handle", mock.Anything)
 
 	go func() {
-		Handle(server, m.Handle)
+		Handle(server, m.Handle, logger.NewNop())
 	}()
 	go func() {
-		Handle(server2, m.Handle)
+		Handle(server2, m.Handle, logger.NewNop())
 	}()
 	duration := time.Second
 	loop := func(s client.Client) {
@@ -98,7 +100,7 @@ func BenchmarkWorker(b *testing.B) {
 	m.m.On("Finished")
 
 	go func() {
-		Handle(server, m.Handle)
+		Handle(server, m.Handle, logger.NewNop())
 		m.Finish()
 	}()
 


### PR DESCRIPTION
The current version of the library doesn't allow to customize logging in any way. For example I'd like to use this library in my application, but my application logs to JSON format. So I'd want this library to log into JSON format as well, but in the current version I have no way how to achieve that.

This PR introduces a generic logging interface which any user of the library can implement on his/her own. To simplify the basic usage with standard go "log" package, it also adds implementation of the logging interface using the standard log package.

It's true that this PR changes the public interface. If that would be an issue, we can add a new factory method which would accept logger to keep the public API unchanged.