### PR TITLE
Use plain Action array rather than array of pooled pointers

### DIFF
--- a/action/action.go
+++ b/action/action.go
@@ -1,9 +1,5 @@
 package action
 
-import (
-	"sync"
-)
-
 type Type byte
 
 type Scope byte
@@ -22,12 +18,6 @@ const (
 	ScopeResponse    Scope = 0x04
 )
 
-var pool = sync.Pool{
-	New: func() interface{} {
-		return newAction()
-	},
-}
-
 type Action struct {
 	Type  Type
 	Scope Scope
@@ -35,42 +25,19 @@ type Action struct {
 	Value interface{}
 }
 
-func (action *Action) SetVar(scope Scope, name string, value interface{}) {
-	action.Type = TypeSetVar
-	action.Scope = scope
-	action.Name = name
-	action.Value = value
-}
-
-func (action *Action) UnsetVar(scope Scope, name string) {
-	action.Type = TypeUnsetVar
-	action.Scope = scope
-	action.Name = name
-}
-
-func newAction() *Action {
-	m := &Action{}
-
-	return m
-}
-
-func AcquireAction() *Action {
-	m := pool.Get()
-	if m == nil {
-		return newAction()
+func NewSetVar(scope Scope, name string, value interface{}) Action {
+	return Action{
+		Type:  TypeSetVar,
+		Scope: scope,
+		Name:  name,
+		Value: value,
 	}
-
-	return m.(*Action)
 }
 
-func ReleaseAction(m *Action) {
-	m.Reset()
-	pool.Put(m)
-}
-
-func (action *Action) Reset() {
-	action.Type = 0
-	action.Scope = 0
-	action.Name = ""
-	action.Value = nil
+func NewUnsetVar(scope Scope, name string) Action {
+	return Action{
+		Type:  TypeUnsetVar,
+		Scope: scope,
+		Name:  name,
+	}
 }

--- a/action/actions.go
+++ b/action/actions.go
@@ -3,15 +3,11 @@ package action
 type Actions []Action
 
 func (actions *Actions) SetVar(scope Scope, name string, value interface{}) {
-	a := Action{}
-	a.SetVar(scope, name, value)
-	*actions = append(*actions, a)
+	*actions = append(*actions, NewSetVar(scope, name, value))
 }
 
 func (actions *Actions) UnsetVar(scope Scope, name string) {
-	a := Action{}
-	a.UnsetVar(scope, name)
-	*actions = append(*actions, a)
+	*actions = append(*actions, NewUnsetVar(scope, name))
 }
 
 func (actions *Actions) Reset() {

--- a/action/actions.go
+++ b/action/actions.go
@@ -1,27 +1,23 @@
 package action
 
-type Actions []*Action
+type Actions []Action
 
 func (actions *Actions) SetVar(scope Scope, name string, value interface{}) {
-	a := AcquireAction()
+	a := Action{}
 	a.SetVar(scope, name, value)
 	*actions = append(*actions, a)
 }
 
 func (actions *Actions) UnsetVar(scope Scope, name string) {
-	a := AcquireAction()
+	a := Action{}
 	a.UnsetVar(scope, name)
 	*actions = append(*actions, a)
 }
 
 func (actions *Actions) Reset() {
-	for _, action := range *actions {
-		ReleaseAction(action)
-	}
-
 	*actions = (*actions)[:0]
 }
 
-func NewActions() *Actions {
-	return &Actions{}
+func NewActions() Actions {
+	return Actions{}
 }

--- a/action/actions.go
+++ b/action/actions.go
@@ -1,5 +1,6 @@
 package action
 
+// TODO: Drop this type and use plain []Action.
 type Actions []Action
 
 func (actions *Actions) SetVar(scope Scope, name string, value interface{}) {
@@ -12,8 +13,4 @@ func (actions *Actions) UnsetVar(scope Scope, name string) {
 
 func (actions *Actions) Reset() {
 	*actions = (*actions)[:0]
-}
-
-func NewActions() Actions {
-	return Actions{}
 }

--- a/action/actions_test.go
+++ b/action/actions_test.go
@@ -1,0 +1,24 @@
+package action_test
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/negasus/haproxy-spoe-go/action"
+)
+
+func BenchmarkActionsPool(b *testing.B) {
+	const str = "foo"
+	as := action.NewActions()
+
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < 200; j++ {
+			as.SetVar(action.ScopeSession, str, nil)
+		}
+		as.Reset()
+
+		if i%150 == 0 {
+			runtime.GC()
+		}
+	}
+}

--- a/action/actions_test.go
+++ b/action/actions_test.go
@@ -9,7 +9,7 @@ import (
 
 func BenchmarkActionsPool(b *testing.B) {
 	const str = "foo"
-	as := action.NewActions()
+	as := make(action.Actions, 0)
 
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < 200; j++ {

--- a/frame/encode.go
+++ b/frame/encode.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"github.com/negasus/haproxy-spoe-go/varint"
 	"io"
+
+	"github.com/negasus/haproxy-spoe-go/varint"
 )
 
 func (f *Frame) Encode(dest io.Writer) (n int, err error) {
@@ -35,8 +36,8 @@ func (f *Frame) Encode(dest io.Writer) (n int, err error) {
 
 	case TypeAgentAck:
 		if f.Actions != nil {
-			for _, act := range *f.Actions {
-				payload, err = (*act).Marshal(payload)
+			for _, act := range f.Actions {
+				payload, err = act.Marshal(payload)
 				if err != nil {
 					return
 				}

--- a/frame/frame.go
+++ b/frame/frame.go
@@ -1,10 +1,11 @@
 package frame
 
 import (
+	"sync"
+
 	"github.com/negasus/haproxy-spoe-go/action"
 	"github.com/negasus/haproxy-spoe-go/message"
 	"github.com/negasus/haproxy-spoe-go/payload/kv"
-	"sync"
 )
 
 type Type byte
@@ -46,7 +47,7 @@ type Frame struct {
 	MaxFrameSize uint32
 	KV           *kv.KV
 	Messages     *message.Messages
-	Actions      *action.Actions
+	Actions      action.Actions
 
 	tmp       [5]byte
 	varintBuf [10]byte

--- a/request/request.go
+++ b/request/request.go
@@ -1,9 +1,10 @@
 package request
 
 import (
+	"sync"
+
 	"github.com/negasus/haproxy-spoe-go/action"
 	"github.com/negasus/haproxy-spoe-go/message"
-	"sync"
 )
 
 var requestPool = sync.Pool{
@@ -17,13 +18,13 @@ type Request struct {
 	StreamID uint64
 	FrameID  uint64
 	Messages *message.Messages
-	Actions  *action.Actions
+	Actions  action.Actions
 }
 
 func newRequest() *Request {
 	m := &Request{
 		Messages: message.NewMessages(),
-		Actions:  action.NewActions(),
+		Actions:  make(action.Actions, 0, 1),
 	}
 
 	return m


### PR DESCRIPTION
Even though `sync.Pool` is supposed to speedup the program by reusing existing allocations, there are some cases when its usage decreases performance. This is the case with actions. I wrote a benchmark which shows that the new version is about twice as fast as the pooled version.