### PR TITLE
bugfix: `false` value has incorrect encoding value - invert flag and value

### DIFF
--- a/typeddata/typeddata.go
+++ b/typeddata/typeddata.go
@@ -51,7 +51,7 @@ func Encode(data interface{}, buf []byte) ([]byte, int, error) {
 	case bool:
 		var b byte = 0x11
 		if !v {
-			b = 0x10
+			b = 0x01
 		}
 		buf = append(buf, b)
 		return buf, 1, nil

--- a/typeddata/typeddata_test.go
+++ b/typeddata/typeddata_test.go
@@ -32,7 +32,7 @@ func TestEncode_Bool(t *testing.T) {
 	if len(buf) != 1 {
 		t.Fatalf("buf len must be 1, got %d", len(buf))
 	}
-	if buf[0] != 0x10 {
+	if buf[0] != 0x01 {
 		t.Fatalf("invalid buf value")
 	}
 


### PR DESCRIPTION
Resolves https://github.com/negasus/haproxy-spoe-go/issues/17

> flags are 0001 and type is 0000 but should be vice versa.