### PR TITLE
🐛 fix(worker): treat connection reset as normal close

### DIFF
--- a/worker/connection_close_test.go
+++ b/worker/connection_close_test.go
@@ -1,0 +1,94 @@
+package worker
+
+import (
+	"errors"
+	"io"
+	"net"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/negasus/haproxy-spoe-go/client"
+	"github.com/negasus/haproxy-spoe-go/request"
+)
+
+func TestIsConnectionClose_EOF(t *testing.T) {
+	if !isConnectionClose(io.EOF) {
+		t.Error("io.EOF should be treated as connection close")
+	}
+}
+
+func TestIsConnectionClose_UnexpectedEOF(t *testing.T) {
+	if !isConnectionClose(io.ErrUnexpectedEOF) {
+		t.Error("io.ErrUnexpectedEOF should be treated as connection close")
+	}
+}
+
+func TestIsConnectionClose_ECONNRESET(t *testing.T) {
+	if !isConnectionClose(syscall.ECONNRESET) {
+		t.Error("ECONNRESET should be treated as connection close")
+	}
+}
+
+func TestIsConnectionClose_EPIPE(t *testing.T) {
+	if !isConnectionClose(syscall.EPIPE) {
+		t.Error("EPIPE should be treated as connection close")
+	}
+}
+
+func TestIsConnectionClose_WrappedECONNRESET(t *testing.T) {
+	err := &net.OpError{
+		Op:  "read",
+		Net: "tcp",
+		Err: syscall.ECONNRESET,
+	}
+	if !isConnectionClose(err) {
+		t.Error("wrapped ECONNRESET in net.OpError should be treated as connection close")
+	}
+}
+
+func TestIsConnectionClose_RandomError(t *testing.T) {
+	if isConnectionClose(errors.New("something unexpected")) {
+		t.Error("arbitrary errors should not be treated as connection close")
+	}
+}
+
+type recordingLogger struct {
+	messages []string
+}
+
+func (l *recordingLogger) Errorf(format string, args ...interface{}) {
+	l.messages = append(l.messages, format)
+}
+
+func TestWorker_ConnectionResetDoesNotLogError(t *testing.T) {
+	clientConn, server := net.Pipe()
+
+	log := &recordingLogger{}
+	done := make(chan struct{})
+
+	go func() {
+		Handle(server, func(r *request.Request) {}, log)
+		close(done)
+	}()
+
+	spoe := client.NewClient(clientConn)
+	if err := spoe.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	// Close the client side abruptly (simulates HAProxy RST)
+	clientConn.Close()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not exit after connection close")
+	}
+
+	for _, msg := range log.messages {
+		if msg == "handle worker: %v" {
+			t.Errorf("connection close should not produce an error log, got: %v", log.messages)
+		}
+	}
+}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -2,10 +2,12 @@ package worker
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"sync"
+	"syscall"
 
 	"github.com/negasus/haproxy-spoe-go/frame"
 	"github.com/negasus/haproxy-spoe-go/logger"
@@ -63,10 +65,10 @@ func (w *worker) run() error {
 
 		if err := f.Read(buf); err != nil {
 			frame.ReleaseFrame(f)
-			if err != io.EOF {
-				return fmt.Errorf("error read frame: %v", err)
+			if isConnectionClose(err) {
+				return nil
 			}
-			return nil
+			return fmt.Errorf("error read frame: %v", err)
 		}
 
 		switch f.Type {
@@ -114,4 +116,19 @@ func (w *worker) run() error {
 			w.logger.Errorf("unexpected frame type: %v", f.Type)
 		}
 	}
+}
+
+// isConnectionClose reports whether err indicates the peer closed the
+// connection. HAProxy 3.x's mux_spop tears down TCP connections without
+// sending a DISCONNECT frame when all SPOP streams are done, resulting
+// in ECONNRESET or EPIPE instead of io.EOF.
+func isConnectionClose(err error) bool {
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.EPIPE) {
+		return true
+	}
+	var netErr *net.OpError
+	return errors.As(err, &netErr) && !netErr.Temporary()
 }


### PR DESCRIPTION
HAProxy 3.1 introduced [`mux_spop`](https://github.com/haproxy/haproxy/commit/7e1bb7283b2663808e5c5872c19cfe9e7970530d), a multiplexed SPOP connection manager that creates and destroys SPOP streams per request. When all streams on a connection complete, the mux tears down the TCP connection with a RST rather than sending a `HAPROXY-DISCONNECT` frame. The worker's frame read loop currently only recognizes `io.EOF` as a clean close, so `ECONNRESET` and `EPIPE` get reported as errors through the logger — generating spurious noise in production deployments. 🔊 HAProxy versions prior to 3.1 (2.x, 3.0) used the older SPOE implementation without the SPOP mux and always sent a proper `HAPROXY-DISCONNECT` frame or closed with FIN, so this was never an issue before.

This adds an `isConnectionClose()` helper that recognizes `ECONNRESET`, `EPIPE`, `io.ErrUnexpectedEOF`, and non-temporary `net.OpError` as equivalent to `io.EOF`, allowing the worker to exit cleanly without reporting an error. ✨ The change is strictly additive and fully backward compatible with pre-3.1 HAProxy — the two existing close paths are unaffected: `HAPROXY-DISCONNECT` frames are still handled by the dedicated case in the frame loop, and clean TCP closes (`io.EOF`) are the first check inside `isConnectionClose()`, preserving identical behavior to the old `err != io.EOF` guard.

This was discovered while running the library with HAProxy 3.1+ SPOE filter using `send-spoe-group` directives, where each SPOE call creates a new SPOP stream and the connection is recycled immediately after the ACK is received.

### HAProxy code references

The connection lifecycle that causes this (all introduced in HAProxy 3.1, first dev tag `v3.1-dev4`):

1. [`flt_spoe.c:1195`](https://github.com/haproxy/haproxy/blob/master/src/flt_spoe.c#L1195) — a new appctx is created for each SPOE message exchange via `spoe_create_appctx()`
2. [`flt_spoe.c:1101-1102`](https://github.com/haproxy/haproxy/blob/master/src/flt_spoe.c#L1101-L1102) — after the ACK is received, `spoe_stop_processing()` detaches the appctx (`sa->spoe_ctx = NULL`) and wakes it
3. [`flt_spoe.c:1034`](https://github.com/haproxy/haproxy/blob/master/src/flt_spoe.c#L1034) — `spoe_release_appctx()` sets `status_code = SPOP_ERR_IO` and the SPOP stream is destroyed
4. [`mux_spop.c:987`](https://github.com/haproxy/haproxy/blob/master/src/mux_spop.c#L987) — once no streams remain, `conn_full_close(conn)` hard-closes the TCP connection, resulting in RST