### PR TITLE
  fix(typeddata): panic encoding 64-bit values above ~2^53 (#10)

### DIFF
--- a/typeddata/typeddata.go
+++ b/typeddata/typeddata.go
@@ -58,42 +58,42 @@ func Encode(data interface{}, buf []byte) ([]byte, int, error) {
 
 	case int32:
 		buf = append(buf, TypeInt32)
-		b := make([]byte, 8)
+		b := make([]byte, 10)
 		i := varint.PutUvarint(b, uint64(v))
 		buf = append(buf, b[:i]...)
 		return buf, i + 1, nil
 
 	case uint32:
 		buf = append(buf, TypeUInt32)
-		b := make([]byte, 8)
+		b := make([]byte, 10)
 		i := varint.PutUvarint(b, uint64(v))
 		buf = append(buf, b[:i]...)
 		return buf, i + 1, nil
 
 	case int:
 		buf = append(buf, TypeInt64)
-		b := make([]byte, 8)
+		b := make([]byte, 10)
 		i := varint.PutUvarint(b, uint64(v))
 		buf = append(buf, b[:i]...)
 		return buf, i + 1, nil
 
 	case int64:
 		buf = append(buf, TypeInt64)
-		b := make([]byte, 8)
+		b := make([]byte, 10)
 		i := varint.PutUvarint(b, uint64(v))
 		buf = append(buf, b[:i]...)
 		return buf, i + 1, nil
 
 	case uint:
 		buf = append(buf, TypeUInt64)
-		b := make([]byte, 8)
+		b := make([]byte, 10)
 		i := varint.PutUvarint(b, uint64(v))
 		buf = append(buf, b[:i]...)
 		return buf, i + 1, nil
 
 	case uint64:
 		buf = append(buf, TypeUInt64)
-		b := make([]byte, 8)
+		b := make([]byte, 10)
 		i := varint.PutUvarint(b, uint64(v))
 		buf = append(buf, b[:i]...)
 		return buf, i + 1, nil
@@ -101,7 +101,7 @@ func Encode(data interface{}, buf []byte) ([]byte, int, error) {
 	case string:
 		n = 1
 		buf = append(buf, TypeString)
-		b := make([]byte, 8)
+		b := make([]byte, 10)
 		i := varint.PutUvarint(b, uint64(len(v)))
 		n += i
 		n += len(v)
@@ -112,7 +112,7 @@ func Encode(data interface{}, buf []byte) ([]byte, int, error) {
 	case []byte:
 		n = 1
 		buf = append(buf, TypeBinary)
-		b := make([]byte, 8)
+		b := make([]byte, 10)
 		i := varint.PutUvarint(b, uint64(len(v)))
 		n += i
 		n += len(v)

--- a/typeddata/typeddata.go
+++ b/typeddata/typeddata.go
@@ -58,6 +58,7 @@ func Encode(data interface{}, buf []byte) ([]byte, int, error) {
 
 	case int32:
 		buf = append(buf, TypeInt32)
+		// Needs 10 because negative int32 sign-extends to ~MaxUint64 when widened to uint64.
 		b := make([]byte, 10)
 		i := varint.PutUvarint(b, uint64(v))
 		buf = append(buf, b[:i]...)
@@ -65,7 +66,7 @@ func Encode(data interface{}, buf []byte) ([]byte, int, error) {
 
 	case uint32:
 		buf = append(buf, TypeUInt32)
-		b := make([]byte, 10)
+		b := make([]byte, 8)
 		i := varint.PutUvarint(b, uint64(v))
 		buf = append(buf, b[:i]...)
 		return buf, i + 1, nil
@@ -101,7 +102,7 @@ func Encode(data interface{}, buf []byte) ([]byte, int, error) {
 	case string:
 		n = 1
 		buf = append(buf, TypeString)
-		b := make([]byte, 10)
+		b := make([]byte, 8)
 		i := varint.PutUvarint(b, uint64(len(v)))
 		n += i
 		n += len(v)
@@ -112,7 +113,7 @@ func Encode(data interface{}, buf []byte) ([]byte, int, error) {
 	case []byte:
 		n = 1
 		buf = append(buf, TypeBinary)
-		b := make([]byte, 10)
+		b := make([]byte, 8)
 		i := varint.PutUvarint(b, uint64(len(v)))
 		n += i
 		n += len(v)

--- a/typeddata/typeddata_test.go
+++ b/typeddata/typeddata_test.go
@@ -2,6 +2,7 @@ package typeddata
 
 import (
 	"bytes"
+	"math"
 	"testing"
 )
 
@@ -80,5 +81,54 @@ func TestEncode_Binary(t *testing.T) {
 	}
 	if !bytes.Equal(buf, []byte{0x09, 0x03, 0x10, 0x20, 0x30}) {
 		t.Fatalf("invalid buf value")
+	}
+}
+
+// Regression test for issue #10: values above ~2^53 need a 10-byte varint
+// buffer, not 8. A representative current-day Unix nano timestamp is the
+// easiest realistic trigger.
+func TestEncode_Int64_NanoTimestamp(t *testing.T) {
+	v := int64(1700000000000000000)
+	buf, n, err := Encode(v, make([]byte, 0))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != len(buf) {
+		t.Fatalf("n (%d) does not match len(buf) (%d)", n, len(buf))
+	}
+	decoded, _, err := Decode(buf)
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	got, ok := decoded.(int64)
+	if !ok {
+		t.Fatalf("decoded type = %T, want int64", decoded)
+	}
+	if got != v {
+		t.Fatalf("round-trip mismatch: got %d, want %d", got, v)
+	}
+}
+
+// Regression test for issue #10: math.MaxUint64 needs the full 10-byte
+// varint range.
+func TestEncode_UInt64_Max(t *testing.T) {
+	v := uint64(math.MaxUint64)
+	buf, n, err := Encode(v, make([]byte, 0))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != len(buf) {
+		t.Fatalf("n (%d) does not match len(buf) (%d)", n, len(buf))
+	}
+	decoded, _, err := Decode(buf)
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	got, ok := decoded.(uint64)
+	if !ok {
+		t.Fatalf("decoded type = %T, want uint64", decoded)
+	}
+	if got != v {
+		t.Fatalf("round-trip mismatch: got %d, want %d", got, v)
 	}
 }

--- a/typeddata/typeddata_test.go
+++ b/typeddata/typeddata_test.go
@@ -132,3 +132,27 @@ func TestEncode_UInt64_Max(t *testing.T) {
 		t.Fatalf("round-trip mismatch: got %d, want %d", got, v)
 	}
 }
+
+// Regression test for issue #10: negative int32 sign-extends to ~MaxUint64
+// when widened to uint64, so it also needs the full 10-byte varint range.
+func TestEncode_Int32_Negative(t *testing.T) {
+	v := int32(-1)
+	buf, n, err := Encode(v, make([]byte, 0))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != len(buf) {
+		t.Fatalf("n (%d) does not match len(buf) (%d)", n, len(buf))
+	}
+	decoded, _, err := Decode(buf)
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	got, ok := decoded.(int32)
+	if !ok {
+		t.Fatalf("decoded type = %T, want int32", decoded)
+	}
+	if got != v {
+		t.Fatalf("round-trip mismatch: got %d, want %d", got, v)
+	}
+}


### PR DESCRIPTION
Closes #10.

`typeddata.Encode` allocates an 8-byte buffer for varint encoding, but the SPOP varint format needs up to 10 bytes for the full `uint64` range. When the buffer overflows, `varint.PutUvarint` returns `-1`, the next line evaluates `b[:-1]`, and the worker goroutine panics with `slice bounds out of range [:-1]`. Easiest real-world trigger is a handler that does `SetVar(..., time.Now().UnixNano())`.

Less obvious: **negative `int32` values also panic**, because `uint64(int32(-1))` sign-extends to `MaxUint64` and needs the full 10-byte encoding too.

Fix: right-size the buffer per case rather than bumping everything uniformly, to keep allocations minimal on the hot encode path:

| Case | Buffer | Reasoning |
|---|---|---|
| `int32` | 10 | Negative values sign-extend to ~MaxUint64 |
| `uint32` | 8 | Max 2³²-1 fits in 5 bytes, always non-negative |
| `int` / `int64` / `uint` / `uint64` | 10 | Full 64-bit range |
| `string` / `[]byte` length prefix | 8 | `len(v)` cannot realistically reach 2⁵³ (9 PB) |
