### PR TITLE
security: bound SPOP frame reads and harden binary parsers

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1,25 +1,69 @@
 package agent
 
 import (
+	"fmt"
 	"net"
 
+	"github.com/negasus/haproxy-spoe-go/frame"
 	"github.com/negasus/haproxy-spoe-go/logger"
 	"github.com/negasus/haproxy-spoe-go/request"
 	"github.com/negasus/haproxy-spoe-go/worker"
 )
 
+type Options struct {
+	// MaxFrameSize is the local safety limit used only when reading the first
+	// HAPROXY-HELLO frame (excluding the 4-byte length prefix). It must be
+	// >= frame.MinFrameSize. After a valid HELLO, the connection uses the
+	// max-frame-size announced by HAProxy for all subsequent frames.
+	//
+	// Size the local limit so a legitimate HAPROXY-HELLO fits (HELLOs are
+	// small; the default is usually enough). Align HAProxy with:
+	//
+	//   spoe-agent <name>
+	//       max-frame-size <value>
+	//
+	// A value of 0 selects the library default; there is no "unlimited" mode.
+	MaxFrameSize uint32
+}
+
 func New(handler func(*request.Request), logger logger.Logger) *Agent {
-	agent := &Agent{
-		handler: handler,
-		logger:  logger,
+	return &Agent{
+		handler:      handler,
+		logger:       logger,
+		maxFrameSize: frame.DefaultMaxFrameSize,
+	}
+}
+
+func NewWithOptions(handler func(*request.Request), logger logger.Logger, opts Options) (*Agent, error) {
+	if opts.MaxFrameSize == 0 {
+		opts.MaxFrameSize = frame.DefaultMaxFrameSize
+	}
+	if err := frame.ValidateMaxFrameSize(opts.MaxFrameSize); err != nil {
+		return nil, fmt.Errorf("agent options: %w", err)
+	}
+	if handler == nil {
+		return nil, fmt.Errorf("agent options: handler must not be nil")
+	}
+	if logger == nil {
+		return nil, fmt.Errorf("agent options: logger must not be nil")
 	}
 
-	return agent
+	return &Agent{
+		handler:      handler,
+		logger:       logger,
+		maxFrameSize: opts.MaxFrameSize,
+	}, nil
 }
 
 type Agent struct {
-	handler func(*request.Request)
-	logger  logger.Logger
+	handler      func(*request.Request)
+	logger       logger.Logger
+	maxFrameSize uint32
+}
+
+// MaxFrameSize returns the configured local maximum frame size.
+func (agent *Agent) MaxFrameSize() uint32 {
+	return agent.maxFrameSize
 }
 
 func (agent *Agent) Serve(listener net.Listener) error {
@@ -32,6 +76,6 @@ func (agent *Agent) Serve(listener net.Listener) error {
 			return err
 		}
 
-		go worker.Handle(conn, agent.handler, agent.logger)
+		go worker.HandleWithMaxFrameSize(conn, agent.handler, agent.logger, agent.maxFrameSize)
 	}
 }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1,0 +1,33 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/negasus/haproxy-spoe-go/frame"
+	"github.com/negasus/haproxy-spoe-go/logger"
+	"github.com/negasus/haproxy-spoe-go/request"
+)
+
+func TestNew_DefaultMaxFrameSize(t *testing.T) {
+	a := New(func(*request.Request) {}, logger.NewNop())
+	if a.MaxFrameSize() != frame.DefaultMaxFrameSize {
+		t.Fatalf("got %d, want %d", a.MaxFrameSize(), frame.DefaultMaxFrameSize)
+	}
+}
+
+func TestNewWithOptions_RejectsInvalid(t *testing.T) {
+	_, err := NewWithOptions(func(*request.Request) {}, logger.NewNop(), Options{MaxFrameSize: 10})
+	if err == nil {
+		t.Fatal("expected error for too-small MaxFrameSize")
+	}
+}
+
+func TestNewWithOptions_ZeroMeansDefault(t *testing.T) {
+	a, err := NewWithOptions(func(*request.Request) {}, logger.NewNop(), Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.MaxFrameSize() != frame.DefaultMaxFrameSize {
+		t.Fatalf("got %d, want default", a.MaxFrameSize())
+	}
+}

--- a/client/client.go
+++ b/client/client.go
@@ -12,13 +12,18 @@ import (
 
 // Client is a simple client for spop protocol, this should only be used for testing purpose
 type Client struct {
-	conn   net.Conn
-	reader io.Reader
+	conn         net.Conn
+	reader       io.Reader
+	maxFrameSize uint32
 }
 
 // NewClient create a new Client for an established connection
 func NewClient(conn net.Conn) Client {
-	return Client{conn: conn, reader: bufio.NewReader(conn)}
+	return Client{
+		conn:         conn,
+		reader:       bufio.NewReader(conn),
+		maxFrameSize: frame.DefaultMaxFrameSize,
+	}
 }
 
 // Init initialize the client by sending the HaproxyHello frame
@@ -29,7 +34,7 @@ func (c *Client) Init() error {
 	f.StreamID = 0
 	f.FrameID = 0
 	f.KV.Add("supported-versions", "2")
-	f.KV.Add("max-frame-size", uint32(16*1024))
+	f.KV.Add("max-frame-size", c.maxFrameSize)
 	f.KV.Add("capabilities", "")
 
 	err := c.send(f)
@@ -39,12 +44,17 @@ func (c *Client) Init() error {
 
 	responseFrame := frame.AcquireFrame()
 	defer frame.ReleaseFrame(responseFrame)
-	responseFrame.Read(c.reader)
+	if err := responseFrame.ReadWithLimit(c.reader, c.maxFrameSize); err != nil {
+		return err
+	}
 
 	switch responseFrame.Type {
 	case frame.TypeAgentHello:
 		if responseFrame.FrameID != uint64(0) || responseFrame.StreamID != uint64(0) {
 			return fmt.Errorf("FrameID or StreamID mismatch")
+		}
+		if responseFrame.MaxFrameSize > 0 && responseFrame.MaxFrameSize < c.maxFrameSize {
+			c.maxFrameSize = responseFrame.MaxFrameSize
 		}
 	default:
 		return fmt.Errorf("unexpected frame type: %v", responseFrame.Type)
@@ -56,16 +66,20 @@ func (c *Client) Init() error {
 
 func (c *Client) send(f *frame.Frame) error {
 	buf := bytes.NewBuffer(make([]byte, 0))
-	n, err := f.Encode(buf)
+	n, err := f.EncodeWithLimit(buf, c.maxFrameSize)
 	if err != nil {
 		return err
 	}
-	n, err = c.conn.Write(buf.Bytes())
-	if err != nil {
-		return err
-	}
-	if n != buf.Len() {
-		return fmt.Errorf("size mismatch")
+	written := 0
+	for written < n {
+		nn, err := c.conn.Write(buf.Bytes()[written:])
+		if err != nil {
+			return err
+		}
+		if nn <= 0 {
+			return fmt.Errorf("short write")
+		}
+		written += nn
 	}
 	return nil
 }
@@ -85,8 +99,7 @@ func (c *Client) Notify() error {
 
 	responseFrame := frame.AcquireFrame()
 	defer frame.ReleaseFrame(responseFrame)
-	responseFrame.Read(c.reader)
-	return nil
+	return responseFrame.ReadWithLimit(c.reader, c.maxFrameSize)
 }
 
 // Stop the client by sending HaproxyDisconnect frame
@@ -106,8 +119,5 @@ func (c *Client) Stop() error {
 
 	responseFrame := frame.AcquireFrame()
 	defer frame.ReleaseFrame(responseFrame)
-	responseFrame.Read(c.reader)
-
-	return nil
-
+	return responseFrame.ReadWithLimit(c.reader, c.maxFrameSize)
 }

--- a/frame/encode.go
+++ b/frame/encode.go
@@ -10,6 +10,13 @@ import (
 )
 
 func (f *Frame) Encode(dest io.Writer) (n int, err error) {
+	return f.EncodeWithLimit(dest, 0)
+}
+
+// EncodeWithLimit marshals the frame to dest. If maxFrameSize is non-zero and
+// the encoded content length (excluding the 4-byte length prefix) would exceed
+// it, encoding fails with ErrFrameTooLarge before writing.
+func (f *Frame) EncodeWithLimit(dest io.Writer, maxFrameSize uint32) (n int, err error) {
 	buf := bytes.Buffer{}
 
 	buf.WriteByte(byte(f.Type))
@@ -19,9 +26,15 @@ func (f *Frame) Encode(dest io.Writer) (n int, err error) {
 	buf.Write(f.tmp[0:4])
 
 	n = varint.PutUvarint(f.varintBuf[:], f.StreamID)
+	if n <= 0 {
+		return 0, fmt.Errorf("encode stream id: %w", ErrMalformedFrame)
+	}
 	buf.Write(f.varintBuf[:n])
 
 	n = varint.PutUvarint(f.varintBuf[:], f.FrameID)
+	if n <= 0 {
+		return 0, fmt.Errorf("encode frame id: %w", ErrMalformedFrame)
+	}
 	buf.Write(f.varintBuf[:n])
 
 	var payload []byte
@@ -49,23 +62,50 @@ func (f *Frame) Encode(dest io.Writer) (n int, err error) {
 
 		}
 	default:
-		err = fmt.Errorf("unexpected frame type %d", f.Type)
+		err = fmt.Errorf("%w %d", ErrUnexpectedFrameType, f.Type)
 		return
 	}
 
 	buf.Write(payload)
 
-	binary.BigEndian.PutUint32(f.tmp[:], uint32(buf.Len()))
-
-	n, err = dest.Write(f.tmp[0:4])
-	if err != nil || n != 4 {
-		return 0, fmt.Errorf("error write frameSize. writes %d, expect %d, err: %v", n, len(f.tmp), err)
+	contentLen := buf.Len()
+	if contentLen < 0 || uint64(contentLen) > uint64(^uint32(0)) {
+		return 0, fmt.Errorf("encoded frame too large: %w", ErrFrameTooLarge)
+	}
+	contentLenU32 := uint32(contentLen)
+	if maxFrameSize > 0 && contentLenU32 > maxFrameSize {
+		return 0, &SizeError{
+			Op:    "encode frame",
+			Len:   contentLenU32,
+			Limit: maxFrameSize,
+			Type:  f.Type,
+			Err:   ErrFrameTooLarge,
+		}
 	}
 
-	n, err = dest.Write(buf.Bytes())
-	if err != nil || n != buf.Len() {
-		return 0, fmt.Errorf("error write frame. writes %d, expect %d, err: %v", n, len(f.tmp), err)
+	binary.BigEndian.PutUint32(f.tmp[:], contentLenU32)
+
+	if err = writeFull(dest, f.tmp[0:4]); err != nil {
+		return 0, fmt.Errorf("error write frameSize: %w", err)
 	}
 
-	return 4 + buf.Len(), nil
+	if err = writeFull(dest, buf.Bytes()); err != nil {
+		return 0, fmt.Errorf("error write frame: %w", err)
+	}
+
+	return HeaderSize + contentLen, nil
+}
+
+func writeFull(w io.Writer, p []byte) error {
+	for len(p) > 0 {
+		n, err := w.Write(p)
+		if err != nil {
+			return err
+		}
+		if n <= 0 {
+			return io.ErrShortWrite
+		}
+		p = p[n:]
+	}
+	return nil
 }

--- a/frame/errors.go
+++ b/frame/errors.go
@@ -1,0 +1,63 @@
+package frame
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrFrameTooLarge is returned when a frame length exceeds the configured
+	// or negotiated maximum frame size.
+	ErrFrameTooLarge = errors.New("frame exceeds maximum size")
+
+	// ErrInvalidFrameLength is returned when the declared frame length is zero
+	// or otherwise invalid for the SPOP framing format.
+	ErrInvalidFrameLength = errors.New("invalid frame length")
+
+	// ErrMalformedFrame is returned when frame metadata or payload cannot be
+	// decoded safely (truncated fields, bad varints, etc.).
+	ErrMalformedFrame = errors.New("malformed frame")
+
+	// ErrUnexpectedFrameType is returned when the frame type byte is not a
+	// known SPOP frame type.
+	ErrUnexpectedFrameType = errors.New("unexpected frame type")
+)
+
+// SizeError describes a rejected frame length. Use errors.Is(err, ErrFrameTooLarge)
+// or errors.Is(err, ErrInvalidFrameLength) to classify the failure.
+type SizeError struct {
+	Op    string
+	Len   uint32
+	Limit uint32
+	Type  Type
+	Err   error
+}
+
+func (e *SizeError) Error() string {
+	if e.Type != 0 {
+		return fmt.Sprintf("%s: declared length %d, limit %d, type %d: %v", e.Op, e.Len, e.Limit, e.Type, e.Err)
+	}
+	return fmt.Sprintf("%s: declared length %d, limit %d: %v", e.Op, e.Len, e.Limit, e.Err)
+}
+
+func (e *SizeError) Unwrap() error {
+	return e.Err
+}
+
+// DecodeError describes a malformed frame payload without embedding untrusted data.
+type DecodeError struct {
+	Op   string
+	Type Type
+	Err  error
+}
+
+func (e *DecodeError) Error() string {
+	if e.Type != 0 {
+		return fmt.Sprintf("%s: type %d: %v", e.Op, e.Type, e.Err)
+	}
+	return fmt.Sprintf("%s: %v", e.Op, e.Err)
+}
+
+func (e *DecodeError) Unwrap() error {
+	return e.Err
+}

--- a/frame/frame.go
+++ b/frame/frame.go
@@ -79,6 +79,12 @@ func (f *Frame) Reset() {
 	f.Actions = nil
 	f.Messages.Reset()
 	f.KV.Reset()
+
+	// Drop oversized read buffers so a single large (but allowed) frame does
+	// not permanently retain memory in the global pool.
+	if cap(f.readBuf) > maxRetainedReadBufCap {
+		f.readBuf = nil
+	}
 }
 
 // IsFin returns true, if frame has flag 'FIN'

--- a/frame/fuzz_test.go
+++ b/frame/fuzz_test.go
@@ -1,0 +1,21 @@
+package frame
+
+import (
+	"bytes"
+	"testing"
+)
+
+func FuzzFrameRead(f *testing.F) {
+	f.Add(testFrame)
+	f.Add([]byte("GET / HTTP/1.1\r\n\r\n"))
+	f.Add([]byte{0, 0, 0, 0, 1})
+	f.Add([]byte{0xff, 0xff, 0xff, 0xff, 3})
+	f.Add([]byte{0, 0, 0, 7, 3, 0, 0, 0, 1, 0, 0})
+	f.Add([]byte{})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		frame := NewFrame()
+		defer ReleaseFrame(frame)
+		_ = frame.ReadWithLimit(bytes.NewReader(data), MinFrameSize)
+	})
+}

--- a/frame/limits.go
+++ b/frame/limits.go
@@ -1,0 +1,43 @@
+package frame
+
+import (
+	"fmt"
+	"math"
+)
+
+const (
+	// MinFrameSize is the minimum max-frame-size allowed by the SPOP
+	// specification (see HAProxy SPOE.txt).
+	MinFrameSize uint32 = 256
+
+	// DefaultMaxFrameSize is the safe default local limit used only when reading
+	// the first HAPROXY-HELLO (before the peer's max-frame-size is known). It
+	// matches a common HAProxy default of (tune.bufsize - 4) with tune.bufsize = 16384.
+	DefaultMaxFrameSize uint32 = 16380
+
+	// HeaderSize is the size of the on-wire length prefix.
+	HeaderSize = 4
+
+	// minFrameContentLen is the smallest valid Len value: type (1) + flags (4)
+	// + stream-id varint (1) + frame-id varint (1).
+	minFrameContentLen uint32 = 7
+
+	// maxRetainedReadBufCap is the largest read buffer capacity kept when a
+	// Frame is returned to the pool. Larger buffers are discarded to limit.
+	maxRetainedReadBufCap = 32 * 1024
+)
+
+func ValidateMaxFrameSize(v uint32) error {
+	if v == 0 {
+		return fmt.Errorf("max-frame-size must be >= %d, got 0", MinFrameSize)
+	}
+	if v < MinFrameSize {
+		return fmt.Errorf("max-frame-size must be >= %d, got %d", MinFrameSize, v)
+	}
+	// Ensure the value can be represented as a positive int on this architecture
+	// so later conversions for make/slice never overflow.
+	if uint64(v) > uint64(math.MaxInt) {
+		return fmt.Errorf("max-frame-size %d exceeds architecture int limit %d", v, math.MaxInt)
+	}
+	return nil
+}

--- a/frame/read.go
+++ b/frame/read.go
@@ -4,35 +4,94 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math"
 
 	"github.com/negasus/haproxy-spoe-go/varint"
 )
 
 func (f *Frame) Read(src io.Reader) error {
-	var n int
-	var err error
+	return f.ReadWithLimit(src, DefaultMaxFrameSize)
+}
 
-	n, err = io.ReadFull(src, f.tmp[:])
+// ReadWithLimit reads a single SPOP frame from src, rejecting any frame whose
+// declared length exceeds maxFrameSize before allocating or reading the payload.
+//
+// maxFrameSize is the negotiated/local SPOP max-frame-size (content length
+// excluding the 4-byte length prefix). A value of 0 is treated as
+// DefaultMaxFrameSize so callers cannot accidentally disable limits.
+func (f *Frame) ReadWithLimit(src io.Reader, maxFrameSize uint32) error {
+	if maxFrameSize == 0 {
+		maxFrameSize = DefaultMaxFrameSize
+	}
+	if err := ValidateMaxFrameSize(maxFrameSize); err != nil {
+		return err
+	}
+
+	n, err := io.ReadFull(src, f.tmp[:])
 	if err != nil {
-		if err == io.EOF {
+		if err == io.EOF && n == 0 {
+			return io.EOF
+		}
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
 			return err
 		}
-		return fmt.Errorf("error read frame size, %v", err)
+		return fmt.Errorf("error read frame size: %w", err)
 	}
 
 	f.Len = binary.BigEndian.Uint32(f.tmp[0:4])
 	f.Type = Type(f.tmp[4])
 
-	// Drop packet that doesn't have defined frame type early, before allocating any buffers
-	// that way spurious connections (say someone calling curl on port) won't cause it to
-	// allocate gigabytes of RAM
-	switch f.Type {
-	case TypeHaproxyHello, TypeHaproxyDisconnect, TypeNotify, TypeAgentHello, TypeAgentDisconnect, TypeAgentAck:
-	default:
-		return fmt.Errorf("unexpected frame type %d", f.Type)
+	if !isKnownFrameType(f.Type) {
+		return &DecodeError{
+			Op:   "read frame",
+			Type: f.Type,
+			Err:  fmt.Errorf("%w %d", ErrUnexpectedFrameType, f.Type),
+		}
 	}
 
-	payloadLen := int(f.Len - 1)
+	if f.Len == 0 {
+		return &SizeError{
+			Op:    "read frame",
+			Len:   f.Len,
+			Limit: maxFrameSize,
+			Type:  f.Type,
+			Err:   ErrInvalidFrameLength,
+		}
+	}
+
+	if f.Len < minFrameContentLen {
+		return &SizeError{
+			Op:    "read frame",
+			Len:   f.Len,
+			Limit: maxFrameSize,
+			Type:  f.Type,
+			Err:   ErrInvalidFrameLength,
+		}
+	}
+
+	if f.Len > maxFrameSize {
+		return &SizeError{
+			Op:    "read frame",
+			Len:   f.Len,
+			Limit: maxFrameSize,
+			Type:  f.Type,
+			Err:   ErrFrameTooLarge,
+		}
+	}
+
+	// Len includes the type byte already consumed from the 5-byte header.
+	payloadLenU32 := f.Len - 1
+	if uint64(payloadLenU32) > uint64(math.MaxInt) {
+		return &SizeError{
+			Op:    "read frame",
+			Len:   f.Len,
+			Limit: maxFrameSize,
+			Type:  f.Type,
+			Err:   ErrFrameTooLarge,
+		}
+	}
+	payloadLen := int(payloadLenU32)
+
 	if cap(f.readBuf) < payloadLen {
 		f.readBuf = make([]byte, payloadLen)
 	} else {
@@ -41,48 +100,117 @@ func (f *Frame) Read(src io.Reader) error {
 
 	n, err = io.ReadFull(src, f.readBuf)
 	if err != nil {
-		return fmt.Errorf("error read frame, %v", err)
+		return fmt.Errorf("error read frame payload: %w", err)
 	}
-
-	if uint32(n) != f.Len-1 {
-		return fmt.Errorf("unexpected frame length %d, expect %d", n, f.Len)
+	if n != payloadLen {
+		return fmt.Errorf("unexpected frame payload length %d, expect %d", n, payloadLen)
 	}
 
 	buf := f.readBuf
 
+	if len(buf) < 4 {
+		return &DecodeError{Op: "decode flags", Type: f.Type, Err: ErrMalformedFrame}
+	}
 	f.Flags = binary.BigEndian.Uint32(buf[0:4])
 	buf = buf[4:]
 
-	f.StreamID, n = varint.Uvarint(buf)
-	buf = buf[n:]
+	var vn int
+	f.StreamID, vn = varint.Uvarint(buf)
+	if vn <= 0 {
+		return &DecodeError{Op: "decode stream id", Type: f.Type, Err: ErrMalformedFrame}
+	}
+	buf = buf[vn:]
 
-	f.FrameID, n = varint.Uvarint(buf)
-	buf = buf[n:]
+	f.FrameID, vn = varint.Uvarint(buf)
+	if vn <= 0 {
+		return &DecodeError{Op: "decode frame id", Type: f.Type, Err: ErrMalformedFrame}
+	}
+	buf = buf[vn:]
 
 	switch f.Type {
-	case TypeHaproxyHello, TypeHaproxyDisconnect:
+	case TypeHaproxyHello, TypeHaproxyDisconnect, TypeAgentHello, TypeAgentDisconnect:
 		if err = f.KV.Unmarshal(buf); err != nil {
-			return err
+			return &DecodeError{Op: "decode kv", Type: f.Type, Err: err}
 		}
-		if v, ok := f.KV.Get("healthcheck"); ok && v.(bool) {
-			f.Healthcheck = true
-		}
-		if v, ok := f.KV.Get("max-frame-size"); ok {
-			f.MaxFrameSize = v.(uint32)
-		}
-		if v, ok := f.KV.Get("engine-id"); ok {
-			f.EngineID = v.(string)
-		}
+		f.applyHelloKV()
 
 	case TypeNotify:
-		err = f.Messages.Decode(buf)
-		if err != nil {
-			return err
+		if err = f.Messages.Decode(buf); err != nil {
+			return &DecodeError{Op: "decode messages", Type: f.Type, Err: err}
 		}
 
+	case TypeAgentAck:
+		// ACK payload is a list of actions; generic readers leave it unparsed.
+
 	default:
-		return fmt.Errorf("unexpected frame type %d", f.Type)
+		return &DecodeError{
+			Op:   "read frame",
+			Type: f.Type,
+			Err:  fmt.Errorf("%w %d", ErrUnexpectedFrameType, f.Type),
+		}
 	}
 
 	return nil
+}
+
+func isKnownFrameType(t Type) bool {
+	switch t {
+	case TypeHaproxyHello, TypeHaproxyDisconnect, TypeNotify,
+		TypeAgentHello, TypeAgentDisconnect, TypeAgentAck:
+		return true
+	default:
+		return false
+	}
+}
+
+func (f *Frame) applyHelloKV() {
+	if v, ok := f.KV.Get("healthcheck"); ok {
+		if b, ok := v.(bool); ok {
+			f.Healthcheck = b
+		}
+	}
+	if v, ok := f.KV.Get("max-frame-size"); ok {
+		if size, ok := asUint32(v); ok {
+			f.MaxFrameSize = size
+		}
+	}
+	if v, ok := f.KV.Get("engine-id"); ok {
+		if s, ok := v.(string); ok {
+			f.EngineID = s
+		}
+	}
+}
+
+func asUint32(v interface{}) (uint32, bool) {
+	switch n := v.(type) {
+	case uint32:
+		return n, true
+	case uint64:
+		if n > math.MaxUint32 {
+			return 0, false
+		}
+		return uint32(n), true
+	case int64:
+		if n < 0 || n > math.MaxUint32 {
+			return 0, false
+		}
+		return uint32(n), true
+	case int32:
+		if n < 0 {
+			return 0, false
+		}
+		return uint32(n), true
+	case int:
+		if n < 0 || uint64(n) > math.MaxUint32 {
+			return 0, false
+		}
+		return uint32(n), true
+	case uint:
+		if uint64(n) > math.MaxUint32 {
+			return 0, false
+		}
+		return uint32(n), true
+	default:
+		return 0, false
+	}
 }

--- a/frame/read_test.go
+++ b/frame/read_test.go
@@ -2,29 +2,225 @@ package frame
 
 import (
 	"bytes"
+	"encoding/binary"
+	"errors"
 	"io"
+	"math"
 	"testing"
 )
 
-var testFrame = []byte(string(
-	"\x00\x00\x00\x53" + // Size
-		"\x03" + //TypeNotify
-		"\x00\x00\x00\x01\xfe\x12\x01\x11\x67\x65\x74" +
-		"\x2d\x69\x70\x2d\x72\x65\x70\x75\x74\x61\x74\x69\x6f\x6e\x04\x02" +
-		"\x69\x70\x06\xc1\xc8\xe3\xde\x04" +
-		"host" + //Host
-		"\x08\x12" +
-		"domain.example.com" + // authtest.ninjas.pl
-		"\x0d\x61\x75\x74\x68\x6f\x72\x69\x7a\x61\x74\x69\x6f\x6e\x00\x06" +
-		"\x63\x6f\x6f\x6b\x69\x65\x00",
-))
+type failOnRead struct {
+	header []byte
+	t      *testing.T
+}
+
+func (r *failOnRead) Read(p []byte) (int, error) {
+	if len(r.header) > 0 {
+		n := copy(p, r.header)
+		r.header = r.header[n:]
+		return n, nil
+	}
+	r.t.Fatal("attempted to read frame payload after header rejection")
+	return 0, io.EOF
+}
+
+func frameHeader(length uint32, typ Type) []byte {
+	b := make([]byte, 5)
+	binary.BigEndian.PutUint32(b[0:4], length)
+	b[4] = byte(typ)
+	return b
+}
+
+func TestReadWithLimit_MaxUint32KnownType(t *testing.T) {
+	src := &failOnRead{
+		header: frameHeader(math.MaxUint32, TypeNotify),
+		t:      t,
+	}
+	f := NewFrame()
+	err := f.ReadWithLimit(src, DefaultMaxFrameSize)
+	if !errors.Is(err, ErrFrameTooLarge) {
+		t.Fatalf("expected ErrFrameTooLarge, got %v", err)
+	}
+	var se *SizeError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected SizeError, got %T", err)
+	}
+	if se.Len != math.MaxUint32 || se.Limit != DefaultMaxFrameSize || se.Type != TypeNotify {
+		t.Fatalf("unexpected SizeError: %+v", se)
+	}
+}
+
+func TestReadWithLimit_ZeroLength(t *testing.T) {
+	src := &failOnRead{
+		header: frameHeader(0, TypeHaproxyHello),
+		t:      t,
+	}
+	f := NewFrame()
+	err := f.ReadWithLimit(src, DefaultMaxFrameSize)
+	if !errors.Is(err, ErrInvalidFrameLength) {
+		t.Fatalf("expected ErrInvalidFrameLength, got %v", err)
+	}
+}
+
+func TestReadWithLimit_TooShortMetadata(t *testing.T) {
+	src := &failOnRead{
+		header: frameHeader(minFrameContentLen-1, TypeNotify),
+		t:      t,
+	}
+	f := NewFrame()
+	err := f.ReadWithLimit(src, DefaultMaxFrameSize)
+	if !errors.Is(err, ErrInvalidFrameLength) {
+		t.Fatalf("expected ErrInvalidFrameLength, got %v", err)
+	}
+}
+
+func TestReadWithLimit_ExactLimitAccepted(t *testing.T) {
+	// Build a Notify whose content length equals MinFrameSize exactly, with a
+	// valid empty message list (even number of padding bytes).
+	const limit = MinFrameSize
+	payload := make([]byte, limit-1) // bytes after type
+	binary.BigEndian.PutUint32(payload[0:4], 0x01)
+	// 2-byte stream id (256) + 1-byte frame id => metadata length 7, remaining 248.
+	payload[4] = 0xF0
+	payload[5] = 0x01
+	payload[6] = 0x00
+	for i := 7; i < len(payload); i += 2 {
+		payload[i] = 0x00   // message name length 0
+		payload[i+1] = 0x00 // nb args 0
+	}
+
+	var buf bytes.Buffer
+	_ = binary.Write(&buf, binary.BigEndian, uint32(limit))
+	buf.WriteByte(byte(TypeNotify))
+	buf.Write(payload)
+
+	f := NewFrame()
+	if err := f.ReadWithLimit(&buf, limit); err != nil {
+		t.Fatalf("expected success at exact limit, got %v", err)
+	}
+	if f.StreamID != 256 || f.FrameID != 0 {
+		t.Fatalf("unexpected ids stream=%d frame=%d", f.StreamID, f.FrameID)
+	}
+}
+
+func TestReadWithLimit_LimitPlusOneRejected(t *testing.T) {
+	src := &failOnRead{
+		header: frameHeader(MinFrameSize+1, TypeNotify),
+		t:      t,
+	}
+	f := NewFrame()
+	err := f.ReadWithLimit(src, MinFrameSize)
+	if !errors.Is(err, ErrFrameTooLarge) {
+		t.Fatalf("expected ErrFrameTooLarge, got %v", err)
+	}
+}
+
+func TestReadWithLimit_UnknownTypeHugeLength(t *testing.T) {
+	src := &failOnRead{
+		header: frameHeader(math.MaxUint32, Type(47)), // 'G' from "GET /"
+		t:      t,
+	}
+	f := NewFrame()
+	err := f.ReadWithLimit(src, DefaultMaxFrameSize)
+	if !errors.Is(err, ErrUnexpectedFrameType) {
+		t.Fatalf("expected ErrUnexpectedFrameType, got %v", err)
+	}
+}
+
+func TestReadWithLimit_EarlyRejectDoesNotReadPayload(t *testing.T) {
+	src := &failOnRead{
+		header: frameHeader(DefaultMaxFrameSize+1, TypeHaproxyHello),
+		t:      t,
+	}
+	f := NewFrame()
+	err := f.ReadWithLimit(src, DefaultMaxFrameSize)
+	if !errors.Is(err, ErrFrameTooLarge) {
+		t.Fatalf("expected ErrFrameTooLarge, got %v", err)
+	}
+}
+
+func TestReadWithLimit_Uint32ToIntBoundary(t *testing.T) {
+	// On all architectures, Len just above DefaultMaxFrameSize must be rejected
+	// without converting a huge uint32 into a negative/overflowed int for make().
+	cases := []uint32{
+		DefaultMaxFrameSize + 1,
+		math.MaxUint32,
+		math.MaxUint32 - 1,
+		uint32(math.MaxInt32) + 1,
+	}
+	for _, length := range cases {
+		if length < minFrameContentLen {
+			continue
+		}
+		src := &failOnRead{
+			header: frameHeader(length, TypeNotify),
+			t:      t,
+		}
+		f := NewFrame()
+		err := f.ReadWithLimit(src, DefaultMaxFrameSize)
+		if err == nil {
+			t.Fatalf("length %d: expected error", length)
+		}
+		if errors.Is(err, ErrFrameTooLarge) || errors.Is(err, ErrInvalidFrameLength) {
+			continue
+		}
+		t.Fatalf("length %d: unexpected error %v", length, err)
+	}
+}
+
+func TestRead_UsesDefaultLimit(t *testing.T) {
+	src := &failOnRead{
+		header: frameHeader(math.MaxUint32, TypeNotify),
+		t:      t,
+	}
+	f := NewFrame()
+	err := f.Read(src)
+	if !errors.Is(err, ErrFrameTooLarge) {
+		t.Fatalf("expected ErrFrameTooLarge from Read, got %v", err)
+	}
+}
+
+func TestValidateMaxFrameSize(t *testing.T) {
+	if err := ValidateMaxFrameSize(0); err == nil {
+		t.Fatal("expected error for 0")
+	}
+	if err := ValidateMaxFrameSize(MinFrameSize - 1); err == nil {
+		t.Fatal("expected error below minimum")
+	}
+	if err := ValidateMaxFrameSize(MinFrameSize); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := ValidateMaxFrameSize(DefaultMaxFrameSize); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestReset_DropsOversizedReadBuf(t *testing.T) {
+	f := NewFrame()
+	f.readBuf = make([]byte, maxRetainedReadBufCap+1)
+	f.Reset()
+	if f.readBuf != nil {
+		t.Fatalf("expected oversized buffer to be dropped, cap=%d", cap(f.readBuf))
+	}
+}
+
+func TestEncodeWithLimit_TooLarge(t *testing.T) {
+	f := NewFrame()
+	f.Type = TypeAgentAck
+	f.Actions = nil
+	// Empty ACK is tiny; use a tiny limit below min content.
+	_, err := f.EncodeWithLimit(&bytes.Buffer{}, 1)
+	if !errors.Is(err, ErrFrameTooLarge) {
+		t.Fatalf("expected ErrFrameTooLarge, got %v", err)
+	}
+}
 
 func TestFrame_Read(t *testing.T) {
 	r := bytes.NewBuffer(testFrame)
 	f := NewFrame()
 	err := f.Read(r)
 	if err != nil {
-		t.Fatal()
+		t.Fatal(err)
 	}
 	if int(f.FrameID) != 1 {
 		t.Fatal("wrong FrameID")
@@ -54,7 +250,6 @@ func TestFrame_Read(t *testing.T) {
 
 func BenchmarkFrame_Read(b *testing.B) {
 	readers := make([]io.Reader, b.N)
-	// prepare readers beforehand, so we don't measure the performance of NewReader
 	for idx := range readers {
 		readers[idx] = bytes.NewBuffer(testFrame)
 	}
@@ -64,5 +259,17 @@ func BenchmarkFrame_Read(b *testing.B) {
 		f := NewFrame()
 		_ = f.Read(readers[i])
 	}
-
 }
+
+var testFrame = []byte(string(
+	"\x00\x00\x00\x53" + // Size
+		"\x03" + //TypeNotify
+		"\x00\x00\x00\x01\xfe\x12\x01\x11\x67\x65\x74" +
+		"\x2d\x69\x70\x2d\x72\x65\x70\x75\x74\x61\x74\x69\x6f\x6e\x04\x02" +
+		"\x69\x70\x06\xc1\xc8\xe3\xde\x04" +
+		"host" + //Host
+		"\x08\x12" +
+		"domain.example.com" + // authtest.ninjas.pl
+		"\x0d\x61\x75\x74\x68\x6f\x72\x69\x7a\x61\x74\x69\x6f\x6e\x00\x06" +
+		"\x63\x6f\x6f\x6b\x69\x65\x00",
+))

--- a/message/decode.go
+++ b/message/decode.go
@@ -1,6 +1,7 @@
 package message
 
 import (
+	"fmt"
 	"github.com/negasus/haproxy-spoe-go/varint"
 )
 
@@ -13,20 +14,37 @@ func (m *Messages) Decode(buf []byte) error {
 		message := AcquireMessage()
 
 		messageNameLen, n := varint.Uvarint(buf)
+		if n <= 0 {
+			ReleaseMessage(message)
+			return fmt.Errorf("message name length: truncated varint")
+		}
 		buf = buf[n:]
-		message.Name = string(buf[:messageNameLen])
-		buf = buf[messageNameLen:]
 
+		if messageNameLen > uint64(len(buf)) {
+			ReleaseMessage(message)
+			return fmt.Errorf("message name length %d exceeds remaining buffer %d", messageNameLen, len(buf))
+		}
+		nameLen := int(messageNameLen)
+		message.Name = string(buf[:nameLen])
+		buf = buf[nameLen:]
+
+		if len(buf) < 1 {
+			ReleaseMessage(message)
+			return fmt.Errorf("missing message arguments count")
+		}
 		nbArgs := int(buf[0])
 		buf = buf[1:]
 
-		n, err := message.KV.UnmarshalNB(buf, nbArgs)
-
+		consumed, err := message.KV.UnmarshalNB(buf, nbArgs)
 		if err != nil {
+			ReleaseMessage(message)
 			return err
 		}
-
-		buf = buf[n:]
+		if consumed < 0 || consumed > len(buf) {
+			ReleaseMessage(message)
+			return fmt.Errorf("invalid kv bytes consumed: %d", consumed)
+		}
+		buf = buf[consumed:]
 
 		*m = append(*m, message)
 	}

--- a/message/decode_malformed_test.go
+++ b/message/decode_malformed_test.go
@@ -1,0 +1,47 @@
+package message
+
+import (
+	"testing"
+)
+
+func TestDecode_Malformed(t *testing.T) {
+	cases := []struct {
+		name string
+		buf  []byte
+	}{
+		{"empty ok", nil},
+		{"truncated name varint", []byte{0xF0}},
+		{"name longer than buffer", []byte{0x05, 'a', 'b'}},
+		{"missing args count", []byte{0x03, 'a', 'b', 'c'}},
+		{"truncated kv", []byte{0x01, 'a', 0x01, 0x03, 'k'}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewMessages()
+			err := m.Decode(tc.buf)
+			if tc.name == "empty ok" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func FuzzMessagesDecode(f *testing.F) {
+	f.Add([]byte{0x03, 'F', 'o', 'o', 0x00})
+	f.Add([]byte{0xFF, 0xFF, 0xFF})
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 4096 {
+			t.Skip()
+		}
+		m := NewMessages()
+		_ = m.Decode(data)
+		m.Reset()
+	})
+}

--- a/payload/kv/kv.go
+++ b/payload/kv/kv.go
@@ -47,7 +47,7 @@ func (kv *KV) Data() []Item {
 }
 
 func (kv *KV) Reset() {
-	kv.m = make([]Item, 0)
+	kv.m = kv.m[:0]
 }
 
 func (kv *KV) Add(key string, value interface{}) {
@@ -69,6 +69,9 @@ func (kv *KV) Bytes() ([]byte, error) {
 
 	for _, item := range kv.m {
 		n := varint.PutUvarint(kv.tmp, uint64(len(item.Name)))
+		if n <= 0 {
+			return nil, fmt.Errorf("error encode KV key length")
+		}
 		buf = append(buf, kv.tmp[:n]...)
 		buf = append(buf, item.Name...)
 
@@ -96,8 +99,11 @@ func (kv *KV) Unmarshal(buf []byte) error {
 		}
 
 		keyLen, n = varint.Uvarint(buf)
+		if n <= 0 {
+			return fmt.Errorf("error unmarshal KV key length: truncated varint")
+		}
 		buf = buf[n:]
-		if len(buf) < int(keyLen) {
+		if keyLen > uint64(len(buf)) {
 			return fmt.Errorf("error unmarshal KV, wrong buf len. Expect %d, got %d", keyLen, len(buf))
 		}
 
@@ -108,6 +114,9 @@ func (kv *KV) Unmarshal(buf []byte) error {
 		if err != nil {
 			return err
 		}
+		if n <= 0 || n > len(buf) {
+			return fmt.Errorf("error unmarshal KV value: invalid byte count %d", n)
+		}
 		buf = buf[n:]
 
 		kv.m = append(kv.m, Item{key, value})
@@ -117,6 +126,10 @@ func (kv *KV) Unmarshal(buf []byte) error {
 }
 
 func (kv *KV) UnmarshalNB(buf []byte, count int) (int, error) {
+	if count < 0 {
+		return 0, fmt.Errorf("negative kv count")
+	}
+
 	var key string
 	var value interface{}
 	var n int
@@ -131,9 +144,12 @@ func (kv *KV) UnmarshalNB(buf []byte, count int) (int, error) {
 		}
 
 		keyLen, n = varint.Uvarint(buf)
+		if n <= 0 {
+			return readBytes, fmt.Errorf("error unmarshal KV key length: truncated varint")
+		}
 		buf = buf[n:]
 		readBytes += n
-		if len(buf) < int(keyLen) {
+		if keyLen > uint64(len(buf)) {
 			return readBytes, fmt.Errorf("error unmarshal KV, wrong buf len. Expect %d, got %d", keyLen, len(buf))
 		}
 
@@ -144,6 +160,9 @@ func (kv *KV) UnmarshalNB(buf []byte, count int) (int, error) {
 		value, n, err = typeddata.Decode(buf)
 		if err != nil {
 			return readBytes, err
+		}
+		if n <= 0 || n > len(buf) {
+			return readBytes, fmt.Errorf("error unmarshal KV value: invalid byte count %d", n)
 		}
 		buf = buf[n:]
 		readBytes += n

--- a/payload/kv/kv_test.go
+++ b/payload/kv/kv_test.go
@@ -1,0 +1,44 @@
+package kv
+
+import (
+	"testing"
+)
+
+func TestUnmarshal_Malformed(t *testing.T) {
+	cases := [][]byte{
+		{0xF0},            // truncated key length varint
+		{0x05, 'a', 'b'},  // key longer than buffer
+		{0x01, 'a'},       // missing value
+		{0x01, 'a', 0x08}, // truncated string typed-data
+		{0x01, 'a', 0x08, 0xFF, 0xFF, 0xFF, 0xFF, 0x0F}, // huge string length
+	}
+
+	for i, buf := range cases {
+		kv := NewKV()
+		if err := kv.Unmarshal(buf); err == nil {
+			t.Fatalf("case %d: expected error", i)
+		}
+	}
+}
+
+func TestUnmarshalNB_Malformed(t *testing.T) {
+	kv := NewKV()
+	if _, err := kv.UnmarshalNB(nil, 1); err == nil {
+		t.Fatal("expected error for empty buffer with count=1")
+	}
+	if _, err := kv.UnmarshalNB([]byte{0x01, 'a'}, -1); err == nil {
+		t.Fatal("expected error for negative count")
+	}
+}
+
+func FuzzKVUnmarshal(f *testing.F) {
+	f.Add([]byte{0x03, 'k', 'e', 'y', 0x08, 0x03, 'a', 'b', 'c'})
+	f.Add([]byte{0xFF})
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 4096 {
+			t.Skip()
+		}
+		kv := NewKV()
+		_ = kv.Unmarshal(data)
+	})
+}

--- a/readme.md
+++ b/readme.md
@@ -68,7 +68,21 @@ func main() {
 	}
 	defer listener.Close()
 
-	a := agent.New(handler, logger.NewDefaultLog())
+	// MaxFrameSize is optional. agent.New(...) is enough for most setups and
+	// uses the default (16380). Use NewWithOptions only when you need a custom
+	// local limit for the first HAPROXY-HELLO. After HELLO, HAProxy's announced
+	// max-frame-size is used for the connection:
+	//
+	//   spoe-agent myagent
+	//       max-frame-size 16380
+	//
+	a, err := agent.NewWithOptions(handler, logger.NewDefaultLog(), agent.Options{
+		MaxFrameSize: 16380, // optional; 0 or omitted via agent.New → default 16380; must be >= 256 if set
+	})
+	if err != nil {
+		log.Printf("error create agent: %v", err)
+		os.Exit(1)
+	}
 
 	if err := a.Serve(listener); err != nil {
 		log.Printf("error agent serve: %+v\n", err)
@@ -107,7 +121,44 @@ func handler(req *request.Request) {
 }
 ```
 
+## Frame size limits (security)
+
+SPOP frames are prefixed with an untrusted 4-byte length. This library always
+applies a finite maximum before allocating or reading a payload:
+
+1. **Local limit** — optional `Options.MaxFrameSize` (default `16380`, minimum
+   `256`) bounds only the first `HAPROXY-HELLO`. Omit it / use `agent.New` for
+   the default. There is no unlimited mode; `0` also selects the default.
+   Size a custom value so a legitimate HELLO fits.
+2. **HAProxy limit** — after a valid HELLO, `AGENT-HELLO` echoes HAProxy's
+   `max-frame-size`, and that value is used for all later inbound and outbound
+   frames on the connection. Invalid or missing peer values cause a controlled
+   disconnect.
+
+Pointing an **HTTP** Kubernetes/load-balancer probe at the binary SPOP port
+produces errors such as `unexpected frame type 47` (`'G'` from `GET /`). That
+is expected: use a **TCP** probe on the SPOP port, or expose a separate HTTP
+port for readiness/liveness. Correct probe configuration is operational
+hygiene; the library itself rejects oversized frames even when the frame type
+is a valid SPOP type (for example a crafted `NOTIFY` with a huge length).
+
 ## API
+
+### Agent options
+
+`MaxFrameSize` is **optional**. Most applications can keep using `agent.New`:
+
+```go
+a := agent.New(handler, log) // uses default MaxFrameSize (16380)
+```
+
+Set it only when you need a custom local limit for the first `HAPROXY-HELLO`:
+
+```go
+a, err := agent.NewWithOptions(handler, log, agent.Options{
+    MaxFrameSize: 16380, // optional; 0 selects the default; if set, must be >= 256
+})
+```
 
 ### Messages
 

--- a/typeddata/decode_malformed_test.go
+++ b/typeddata/decode_malformed_test.go
@@ -1,0 +1,48 @@
+package typeddata
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestDecode_Malformed(t *testing.T) {
+	cases := []struct {
+		name string
+		buf  []byte
+	}{
+		{"empty", nil},
+		{"truncated int", []byte{TypeInt32, 0xF0}},
+		{"short ipv4", []byte{TypeIPv4, 1, 2}},
+		{"short ipv6", []byte{TypeIPv6, 1, 2, 3}},
+		{"truncated string len", []byte{TypeString, 0xF0}},
+		{"string longer than buf", []byte{TypeString, 0x10, 'a'}},
+		{"huge binary len", []byte{TypeBinary, 0xFF, 0xFF, 0xFF, 0xFF, 0x0F}},
+		{"unknown type", []byte{0x0F}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := Decode(tc.buf)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+
+	_, _, err := Decode(nil)
+	if !errors.Is(err, ErrEmptyBuffer) {
+		t.Fatalf("expected ErrEmptyBuffer, got %v", err)
+	}
+}
+
+func FuzzTypedDataDecode(f *testing.F) {
+	f.Add([]byte{TypeBoolean | 0x10})
+	f.Add([]byte{TypeString, 0x03, 'a', 'b', 'c'})
+	f.Add([]byte{TypeBinary, 0x02, 0x01, 0x02})
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 4096 {
+			t.Skip()
+		}
+		_, _, _ = Decode(data)
+	})
+}

--- a/typeddata/typeddata.go
+++ b/typeddata/typeddata.go
@@ -147,43 +147,75 @@ func Decode(buf []byte) (data interface{}, n int, err error) {
 
 	case TypeInt32:
 		i, l := varint.Uvarint(buf)
+		if l <= 0 {
+			err = ErrDecodingBufferTooSmall
+			return
+		}
 		n += l
 		data = int32(i)
 		return
 
 	case TypeUInt32:
 		i, l := varint.Uvarint(buf)
+		if l <= 0 {
+			err = ErrDecodingBufferTooSmall
+			return
+		}
 		n += l
 		data = uint32(i)
 		return
 
 	case TypeInt64:
 		i, l := varint.Uvarint(buf)
+		if l <= 0 {
+			err = ErrDecodingBufferTooSmall
+			return
+		}
 		n += l
 		data = int64(i)
 		return
 
 	case TypeUInt64:
 		i, l := varint.Uvarint(buf)
+		if l <= 0 {
+			err = ErrDecodingBufferTooSmall
+			return
+		}
 		n += l
 		data = uint64(i)
 		return
 
 	case TypeIPv4:
-		data = net.IP(buf[:4])
+		if len(buf) < 4 {
+			err = ErrDecodingBufferTooSmall
+			return
+		}
+		ip := make(net.IP, 4)
+		copy(ip, buf[:4])
+		data = ip
 		n += 4
 		return
 
 	case TypeIPv6:
-		data = net.IP(buf[:16])
+		if len(buf) < 16 {
+			err = ErrDecodingBufferTooSmall
+			return
+		}
+		ip := make(net.IP, 16)
+		copy(ip, buf[:16])
+		data = ip
 		n += 16
 		return
 
 	case TypeString:
 		sLen, i := varint.Uvarint(buf)
+		if i <= 0 {
+			err = ErrDecodingBufferTooSmall
+			return
+		}
 		n += i
 		buf = buf[i:]
-		if len(buf) < int(sLen) {
+		if sLen > uint64(len(buf)) {
 			err = ErrDecodingBufferTooSmall
 			return
 		}
@@ -193,13 +225,20 @@ func Decode(buf []byte) (data interface{}, n int, err error) {
 
 	case TypeBinary:
 		dataLen, i := varint.Uvarint(buf)
-		n += i
-		buf = buf[i:]
-		if len(buf) < int(dataLen) {
+		if i <= 0 {
 			err = ErrDecodingBufferTooSmall
 			return
 		}
-		data = buf[:dataLen]
+		n += i
+		buf = buf[i:]
+		if dataLen > uint64(len(buf)) {
+			err = ErrDecodingBufferTooSmall
+			return
+		}
+		// Copy so callers do not retain aliases into the frame buffer.
+		b := make([]byte, int(dataLen))
+		copy(b, buf[:dataLen])
+		data = b
 		n += int(dataLen)
 		return
 	}

--- a/varint/fuzz_test.go
+++ b/varint/fuzz_test.go
@@ -1,0 +1,19 @@
+package varint
+
+import "testing"
+
+func FuzzUvarint(f *testing.F) {
+	f.Add([]byte{0xEF})
+	f.Add([]byte{0xF0})
+	f.Add([]byte{0xF0, 0x01})
+	f.Add([]byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF})
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 32 {
+			t.Skip()
+		}
+		_, n := Uvarint(data)
+		if n > len(data) {
+			t.Fatalf("n=%d > len=%d", n, len(data))
+		}
+	})
+}

--- a/worker/frame_agenthello.go
+++ b/worker/frame_agenthello.go
@@ -1,15 +1,30 @@
 package worker
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/negasus/haproxy-spoe-go/frame"
 )
 
 func (w *worker) sendAgentHello(haproxyHello *frame.Frame) error {
-	var err error
-	var frameSize, n int
+	if haproxyHello.MaxFrameSize == 0 {
+		msg := "max-frame-size value not found or invalid type"
+		if err := w.sendAgentDisconnect(haproxyHello.StreamID, haproxyHello.FrameID, statusMaxFrameSizeNotFound, msg); err != nil {
+			return err
+		}
+		return fmt.Errorf("%s", msg)
+	}
+
+	// After the first HELLO (bounded by the local safety limit), the peer's
+	// max-frame-size is authoritative for the rest of the connection.
+	if err := frame.ValidateMaxFrameSize(haproxyHello.MaxFrameSize); err != nil {
+		msg := "max-frame-size too big or too small"
+		if discErr := w.sendAgentDisconnect(haproxyHello.StreamID, haproxyHello.FrameID, statusMaxFrameSizeInvalid, msg); discErr != nil {
+			return discErr
+		}
+		return err
+	}
+	peerMax := haproxyHello.MaxFrameSize
 
 	agentHello := frame.AcquireFrame()
 	defer frame.ReleaseFrame(agentHello)
@@ -19,23 +34,14 @@ func (w *worker) sendAgentHello(haproxyHello *frame.Frame) error {
 	agentHello.StreamID = haproxyHello.StreamID
 
 	agentHello.KV.Add("version", "2.0")
-	agentHello.KV.Add("max-frame-size", haproxyHello.MaxFrameSize)
+	agentHello.KV.Add("max-frame-size", peerMax)
 	agentHello.KV.Add("capabilities", capabilities)
 
-	buf := bytes.NewBuffer(make([]byte, 0))
-
-	frameSize, err = agentHello.Encode(buf)
-	if err != nil {
-		return fmt.Errorf("marshaling error: %v", err)
+	if err := w.writeFrame(agentHello); err != nil {
+		return err
 	}
 
-	n, err = w.conn.Write(buf.Bytes())
-	if err != nil {
-		return fmt.Errorf("error write to connection: %v", err)
-	}
-	if n != frameSize {
-		return fmt.Errorf("write unexpected bytes count %d, expect %d", n, frameSize)
-	}
-
+	// Switch from the local HELLO-only limit to HAProxy's announced value.
+	w.maxFrameSize = peerMax
 	return nil
 }

--- a/worker/frame_disconnect.go
+++ b/worker/frame_disconnect.go
@@ -1,37 +1,32 @@
 package worker
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/negasus/haproxy-spoe-go/frame"
 )
 
-func (w *worker) sendAgentDisconnect(f *frame.Frame, statusCode uint32, message string) error {
-	var frameSize, n int
-	var err error
-
+func (w *worker) sendAgentDisconnect(streamID, frameID uint64, statusCode uint32, message string) error {
 	agentDisconnectFrame := frame.AcquireFrame()
 	defer frame.ReleaseFrame(agentDisconnectFrame)
 
 	agentDisconnectFrame.Type = frame.TypeAgentDisconnect
-	agentDisconnectFrame.FrameID = f.FrameID
-	agentDisconnectFrame.StreamID = f.StreamID
+	agentDisconnectFrame.FrameID = frameID
+	agentDisconnectFrame.StreamID = streamID
+
+	// Keep the disconnect message short so the disconnect frame itself stays
+	// within the current max-frame-size (local limit before negotiation, or
+	// negotiated afterwards)
+	const maxMsgLen = 64
+	if len(message) > maxMsgLen {
+		message = message[:maxMsgLen]
+	}
+
 	agentDisconnectFrame.KV.Add("status-code", statusCode)
 	agentDisconnectFrame.KV.Add("message", message)
 
-	buf := &bytes.Buffer{}
-	frameSize, err = agentDisconnectFrame.Encode(buf)
-	if err != nil {
-		return err
-	}
-
-	n, err = w.conn.Write(buf.Bytes())
-	if err != nil {
-		return err
-	}
-	if n != frameSize {
-		return fmt.Errorf("write unexpected bytes count %d, expect %d", n, frameSize)
+	if err := w.writeFrame(agentDisconnectFrame); err != nil {
+		return fmt.Errorf("error write AgentDisconnect: %w", err)
 	}
 
 	return nil

--- a/worker/frame_notify.go
+++ b/worker/frame_notify.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 
 	"github.com/negasus/haproxy-spoe-go/frame"
@@ -32,25 +33,44 @@ func (w *worker) processNotifyFrame(f *frame.Frame) {
 
 	err := w.writeFrame(ackFrame)
 	if err != nil {
+		if errors.Is(err, frame.ErrFrameTooLarge) {
+			// ACK exceeded negotiated max-frame-size; notify peer then close path via log.
+			_ = w.sendAgentDisconnect(0, 0, statusFrameTooBig, "ack frame too big")
+		}
 		w.logger.Errorf("ack frame write failed: %v", err)
 	}
 }
 
 func (w *worker) writeFrame(f *frame.Frame) error {
 	buf := bytes.NewBuffer(make([]byte, 0))
-	n, err := f.Encode(buf)
+	n, err := f.EncodeWithLimit(buf, w.maxFrameSize)
 	if err != nil {
 		return fmt.Errorf("cannot marshal frame: %w", err)
 	}
+	if n != buf.Len() {
+		return fmt.Errorf("encoded size mismatch %d, expect %d", n, buf.Len())
+	}
 
-	n, err = w.conn.Write(buf.Bytes())
-	if err != nil {
+	// Encode off the writer goroutine; only the socket write is serialized.
+	errc := make(chan error, 1)
+	w.writeCh <- writeRequest{data: buf.Bytes(), errc: errc}
+	if err := <-errc; err != nil {
 		return fmt.Errorf("cannot write frame to connection: %w", err)
 	}
 
-	if n != buf.Len() {
-		return fmt.Errorf("wrote wrong number of bytes count %d, expect %d", n, buf.Len())
-	}
+	return nil
+}
 
+func writeFull(w interface{ Write([]byte) (int, error) }, p []byte) error {
+	for len(p) > 0 {
+		n, err := w.Write(p)
+		if err != nil {
+			return err
+		}
+		if n <= 0 {
+			return fmt.Errorf("short write")
+		}
+		p = p[n:]
+	}
 	return nil
 }

--- a/worker/negotiate_test.go
+++ b/worker/negotiate_test.go
@@ -1,0 +1,573 @@
+package worker
+
+import (
+	"bufio"
+	"encoding/binary"
+	"errors"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/negasus/haproxy-spoe-go/action"
+	"github.com/negasus/haproxy-spoe-go/frame"
+	"github.com/negasus/haproxy-spoe-go/logger"
+	"github.com/negasus/haproxy-spoe-go/request"
+)
+
+func readFrame(t *testing.T, r io.Reader, limit uint32) *frame.Frame {
+	t.Helper()
+	f := frame.AcquireFrame()
+	if err := f.ReadWithLimit(r, limit); err != nil {
+		frame.ReleaseFrame(f)
+		t.Fatalf("read frame: %v", err)
+	}
+	return f
+}
+
+func TestNegotiate_LocalSmallerThanHAProxy(t *testing.T) {
+	clientConn, server := net.Pipe()
+	defer clientConn.Close()
+
+	// Local limit only bounds the first HELLO; after that HAProxy's value wins.
+	go HandleWithMaxFrameSize(server, func(*request.Request) {}, logger.NewNop(), 1024)
+
+	hello := frame.AcquireFrame()
+	hello.Type = frame.TypeHaproxyHello
+	hello.KV.Add("supported-versions", "2.0")
+	hello.KV.Add("max-frame-size", uint32(4096))
+	hello.KV.Add("capabilities", "")
+	sendFrame(t, clientConn, hello)
+	frame.ReleaseFrame(hello)
+
+	resp := readFrame(t, bufio.NewReader(clientConn), 4096)
+	defer frame.ReleaseFrame(resp)
+	if resp.Type != frame.TypeAgentHello {
+		t.Fatalf("got type %v", resp.Type)
+	}
+	if resp.MaxFrameSize != 4096 {
+		t.Fatalf("connection max-frame-size = %d, want 4096 (HAProxy value)", resp.MaxFrameSize)
+	}
+}
+
+func TestNegotiate_LocalLargerThanHAProxy(t *testing.T) {
+	clientConn, server := net.Pipe()
+	defer clientConn.Close()
+
+	go HandleWithMaxFrameSize(server, func(*request.Request) {}, logger.NewNop(), 8192)
+
+	hello := frame.AcquireFrame()
+	hello.Type = frame.TypeHaproxyHello
+	hello.KV.Add("supported-versions", "2.0")
+	hello.KV.Add("max-frame-size", uint32(2048))
+	hello.KV.Add("capabilities", "")
+	sendFrame(t, clientConn, hello)
+	frame.ReleaseFrame(hello)
+
+	resp := readFrame(t, bufio.NewReader(clientConn), 8192)
+	defer frame.ReleaseFrame(resp)
+	if resp.MaxFrameSize != 2048 {
+		t.Fatalf("negotiated max-frame-size = %d, want 2048", resp.MaxFrameSize)
+	}
+}
+
+func TestNegotiate_Equal(t *testing.T) {
+	clientConn, server := net.Pipe()
+	defer clientConn.Close()
+
+	go HandleWithMaxFrameSize(server, func(*request.Request) {}, logger.NewNop(), 2048)
+
+	hello := frame.AcquireFrame()
+	hello.Type = frame.TypeHaproxyHello
+	hello.KV.Add("supported-versions", "2.0")
+	hello.KV.Add("max-frame-size", uint32(2048))
+	hello.KV.Add("capabilities", "")
+	sendFrame(t, clientConn, hello)
+	frame.ReleaseFrame(hello)
+
+	resp := readFrame(t, bufio.NewReader(clientConn), 2048)
+	defer frame.ReleaseFrame(resp)
+	if resp.MaxFrameSize != 2048 {
+		t.Fatalf("negotiated max-frame-size = %d, want 2048", resp.MaxFrameSize)
+	}
+}
+
+func TestNegotiate_MissingMaxFrameSize(t *testing.T) {
+	clientConn, server := net.Pipe()
+	defer clientConn.Close()
+
+	done := make(chan struct{})
+	go func() {
+		HandleWithMaxFrameSize(server, func(*request.Request) {}, logger.NewNop(), 2048)
+		close(done)
+	}()
+
+	hello := frame.AcquireFrame()
+	hello.Type = frame.TypeHaproxyHello
+	hello.KV.Add("supported-versions", "2.0")
+	hello.KV.Add("capabilities", "")
+	sendFrame(t, clientConn, hello)
+	frame.ReleaseFrame(hello)
+
+	resp := readFrame(t, bufio.NewReader(clientConn), 2048)
+	defer frame.ReleaseFrame(resp)
+	if resp.Type != frame.TypeAgentDisconnect {
+		t.Fatalf("got type %v, want AgentDisconnect", resp.Type)
+	}
+	code, ok := resp.KV.Get("status-code")
+	if !ok || code.(uint32) != statusMaxFrameSizeNotFound {
+		t.Fatalf("status-code = %v", code)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not exit")
+	}
+}
+
+func TestNegotiate_WrongMaxFrameSizeType(t *testing.T) {
+	clientConn, server := net.Pipe()
+	defer clientConn.Close()
+
+	done := make(chan struct{})
+	go func() {
+		HandleWithMaxFrameSize(server, func(*request.Request) {}, logger.NewNop(), 2048)
+		close(done)
+	}()
+
+	hello := frame.AcquireFrame()
+	hello.Type = frame.TypeHaproxyHello
+	hello.KV.Add("supported-versions", "2.0")
+	hello.KV.Add("max-frame-size", "not-a-number")
+	hello.KV.Add("capabilities", "")
+	sendFrame(t, clientConn, hello)
+	frame.ReleaseFrame(hello)
+
+	resp := readFrame(t, bufio.NewReader(clientConn), 2048)
+	defer frame.ReleaseFrame(resp)
+	if resp.Type != frame.TypeAgentDisconnect {
+		t.Fatalf("got type %v, want AgentDisconnect", resp.Type)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not exit")
+	}
+}
+
+func TestNegotiate_BelowProtocolMinimum(t *testing.T) {
+	clientConn, server := net.Pipe()
+	defer clientConn.Close()
+
+	done := make(chan struct{})
+	go func() {
+		HandleWithMaxFrameSize(server, func(*request.Request) {}, logger.NewNop(), 2048)
+		close(done)
+	}()
+
+	hello := frame.AcquireFrame()
+	hello.Type = frame.TypeHaproxyHello
+	hello.KV.Add("supported-versions", "2.0")
+	hello.KV.Add("max-frame-size", uint32(100))
+	hello.KV.Add("capabilities", "")
+	sendFrame(t, clientConn, hello)
+	frame.ReleaseFrame(hello)
+
+	resp := readFrame(t, bufio.NewReader(clientConn), 2048)
+	defer frame.ReleaseFrame(resp)
+	if resp.Type != frame.TypeAgentDisconnect {
+		t.Fatalf("got type %v, want AgentDisconnect", resp.Type)
+	}
+	code, _ := resp.KV.Get("status-code")
+	if code.(uint32) != statusMaxFrameSizeInvalid {
+		t.Fatalf("status-code = %v, want %d", code, statusMaxFrameSizeInvalid)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not exit")
+	}
+}
+
+func TestFirstHelloExceedsLocalLimit(t *testing.T) {
+	clientConn, server := net.Pipe()
+	defer clientConn.Close()
+
+	log := &recordingLogger{}
+	done := make(chan struct{})
+	go func() {
+		HandleWithMaxFrameSize(server, func(*request.Request) {}, log, frame.MinFrameSize)
+		close(done)
+	}()
+
+	// Craft a HAPROXY-HELLO whose content length exceeds the local limit.
+	hdr := make([]byte, 5)
+	binary.BigEndian.PutUint32(hdr[0:4], frame.MinFrameSize+1)
+	hdr[4] = byte(frame.TypeHaproxyHello)
+	if _, err := clientConn.Write(hdr); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not exit")
+	}
+
+	found := false
+	for _, msg := range log.messages {
+		if strings.Contains(msg, "handle worker") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected protocol error log, got %v", log.messages)
+	}
+}
+
+func TestNotifyExceedsNegotiatedLimit(t *testing.T) {
+	clientConn, server := net.Pipe()
+	defer clientConn.Close()
+
+	done := make(chan struct{})
+	go func() {
+		HandleWithMaxFrameSize(server, func(*request.Request) {}, logger.NewNop(), 512)
+		close(done)
+	}()
+
+	reader := bufio.NewReader(clientConn)
+	hello := frame.AcquireFrame()
+	hello.Type = frame.TypeHaproxyHello
+	hello.KV.Add("supported-versions", "2.0")
+	hello.KV.Add("max-frame-size", uint32(512))
+	hello.KV.Add("capabilities", "")
+	sendFrame(t, clientConn, hello)
+	frame.ReleaseFrame(hello)
+	resp := readFrame(t, reader, 512)
+	frame.ReleaseFrame(resp)
+
+	hdr := make([]byte, 5)
+	binary.BigEndian.PutUint32(hdr[0:4], 513)
+	hdr[4] = byte(frame.TypeNotify)
+	if _, err := clientConn.Write(hdr); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not exit")
+	}
+}
+
+func TestUnexpectedTypeBeforeHandshake(t *testing.T) {
+	clientConn, server := net.Pipe()
+	defer clientConn.Close()
+
+	done := make(chan struct{})
+	go func() {
+		HandleWithMaxFrameSize(server, func(*request.Request) {}, logger.NewNop(), 2048)
+		close(done)
+	}()
+
+	notify := frame.AcquireFrame()
+	notify.Type = frame.TypeNotify
+	notify.StreamID = 1
+	notify.FrameID = 1
+	sendFrame(t, clientConn, notify)
+	frame.ReleaseFrame(notify)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not exit")
+	}
+}
+
+func TestSecondHelloAfterHandshake(t *testing.T) {
+	clientConn, server := net.Pipe()
+	defer clientConn.Close()
+
+	done := make(chan struct{})
+	go func() {
+		HandleWithMaxFrameSize(server, func(*request.Request) {}, logger.NewNop(), 2048)
+		close(done)
+	}()
+
+	reader := bufio.NewReader(clientConn)
+	hello := frame.AcquireFrame()
+	hello.Type = frame.TypeHaproxyHello
+	hello.KV.Add("supported-versions", "2.0")
+	hello.KV.Add("max-frame-size", uint32(2048))
+	hello.KV.Add("capabilities", "")
+	sendFrame(t, clientConn, hello)
+	frame.ReleaseFrame(hello)
+	resp := readFrame(t, reader, 2048)
+	frame.ReleaseFrame(resp)
+
+	hello2 := frame.AcquireFrame()
+	hello2.Type = frame.TypeHaproxyHello
+	hello2.KV.Add("supported-versions", "2.0")
+	hello2.KV.Add("max-frame-size", uint32(2048))
+	hello2.KV.Add("capabilities", "")
+	sendFrame(t, clientConn, hello2)
+	frame.ReleaseFrame(hello2)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not exit")
+	}
+}
+
+func TestHealthcheckSPOP(t *testing.T) {
+	clientConn, server := net.Pipe()
+	defer clientConn.Close()
+
+	done := make(chan struct{})
+	go func() {
+		HandleWithMaxFrameSize(server, func(*request.Request) {}, logger.NewNop(), 2048)
+		close(done)
+	}()
+
+	hello := frame.AcquireFrame()
+	hello.Type = frame.TypeHaproxyHello
+	hello.KV.Add("supported-versions", "2.0")
+	hello.KV.Add("max-frame-size", uint32(2048))
+	hello.KV.Add("capabilities", "")
+	hello.KV.Add("healthcheck", true)
+	sendFrame(t, clientConn, hello)
+	frame.ReleaseFrame(hello)
+
+	resp := readFrame(t, bufio.NewReader(clientConn), 2048)
+	defer frame.ReleaseFrame(resp)
+	if resp.Type != frame.TypeAgentHello {
+		t.Fatalf("got type %v", resp.Type)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not exit after healthcheck")
+	}
+}
+
+func TestACKWithinLimit(t *testing.T) {
+	clientConn, server := net.Pipe()
+	defer clientConn.Close()
+
+	go HandleWithMaxFrameSize(server, func(r *request.Request) {
+		r.Actions.SetVar(action.ScopeSession, "x", int32(1))
+	}, logger.NewNop(), 2048)
+
+	reader := bufio.NewReader(clientConn)
+	hello := frame.AcquireFrame()
+	hello.Type = frame.TypeHaproxyHello
+	hello.KV.Add("supported-versions", "2.0")
+	hello.KV.Add("max-frame-size", uint32(2048))
+	hello.KV.Add("capabilities", "")
+	sendFrame(t, clientConn, hello)
+	frame.ReleaseFrame(hello)
+	frame.ReleaseFrame(readFrame(t, reader, 2048))
+
+	notify := frame.AcquireFrame()
+	notify.Type = frame.TypeNotify
+	notify.StreamID = 1
+	notify.FrameID = 1
+	sendFrame(t, clientConn, notify)
+	frame.ReleaseFrame(notify)
+
+	ack := readFrame(t, reader, 2048)
+	defer frame.ReleaseFrame(ack)
+	if ack.Type != frame.TypeAgentAck {
+		t.Fatalf("got type %v", ack.Type)
+	}
+}
+
+func TestACKExceedsNegotiatedLimit(t *testing.T) {
+	clientConn, server := net.Pipe()
+	defer clientConn.Close()
+
+	go HandleWithMaxFrameSize(server, func(r *request.Request) {
+		// Force a large ACK payload via a huge variable value.
+		r.Actions.SetVar(action.ScopeSession, "big", strings.Repeat("a", 600))
+	}, logger.NewNop(), 512)
+
+	reader := bufio.NewReader(clientConn)
+	hello := frame.AcquireFrame()
+	hello.Type = frame.TypeHaproxyHello
+	hello.KV.Add("supported-versions", "2.0")
+	hello.KV.Add("max-frame-size", uint32(512))
+	hello.KV.Add("capabilities", "")
+	sendFrame(t, clientConn, hello)
+	frame.ReleaseFrame(hello)
+	frame.ReleaseFrame(readFrame(t, reader, 512))
+
+	notify := frame.AcquireFrame()
+	notify.Type = frame.TypeNotify
+	notify.StreamID = 1
+	notify.FrameID = 1
+	sendFrame(t, clientConn, notify)
+	frame.ReleaseFrame(notify)
+
+	// Expect AGENT-DISCONNECT with frame-too-big after ACK encode fails.
+	_ = clientConn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	f := frame.AcquireFrame()
+	defer frame.ReleaseFrame(f)
+	err := f.ReadWithLimit(reader, 512)
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+		// disconnect frame may arrive, or connection may close
+		if f.Type != frame.TypeAgentDisconnect && f.Type != 0 {
+			t.Fatalf("unexpected type %v err=%v", f.Type, err)
+		}
+	}
+	if err == nil && f.Type != frame.TypeAgentDisconnect {
+		t.Fatalf("expected AgentDisconnect, got %v", f.Type)
+	}
+}
+
+type partialWriterConn struct {
+	net.Conn
+	chunk int
+}
+
+func (c *partialWriterConn) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	n := c.chunk
+	if n > len(p) {
+		n = len(p)
+	}
+	return c.Conn.Write(p[:n])
+}
+
+func TestPartialWrites(t *testing.T) {
+	clientConn, server := net.Pipe()
+	defer clientConn.Close()
+
+	partial := &partialWriterConn{Conn: server, chunk: 3}
+	go HandleWithMaxFrameSize(partial, func(*request.Request) {}, logger.NewNop(), 2048)
+
+	reader := bufio.NewReader(clientConn)
+	hello := frame.AcquireFrame()
+	hello.Type = frame.TypeHaproxyHello
+	hello.KV.Add("supported-versions", "2.0")
+	hello.KV.Add("max-frame-size", uint32(2048))
+	hello.KV.Add("capabilities", "")
+	sendFrame(t, clientConn, hello)
+	frame.ReleaseFrame(hello)
+
+	resp := readFrame(t, reader, 2048)
+	defer frame.ReleaseFrame(resp)
+	if resp.Type != frame.TypeAgentHello {
+		t.Fatalf("got type %v", resp.Type)
+	}
+}
+
+func TestParallelACKNoInterleaving(t *testing.T) {
+	clientConn, server := net.Pipe()
+	defer clientConn.Close()
+
+	var started sync.WaitGroup
+	var release chan struct{}
+	release = make(chan struct{})
+	var count int32
+
+	go HandleWithMaxFrameSize(server, func(r *request.Request) {
+		atomic.AddInt32(&count, 1)
+		started.Done()
+		<-release
+		r.Actions.SetVar(action.ScopeSession, "id", int32(r.FrameID))
+	}, logger.NewNop(), 4096)
+
+	reader := bufio.NewReader(clientConn)
+	hello := frame.AcquireFrame()
+	hello.Type = frame.TypeHaproxyHello
+	hello.KV.Add("supported-versions", "2.0")
+	hello.KV.Add("max-frame-size", uint32(4096))
+	hello.KV.Add("capabilities", "")
+	sendFrame(t, clientConn, hello)
+	frame.ReleaseFrame(hello)
+	frame.ReleaseFrame(readFrame(t, reader, 4096))
+
+	const n = 8
+	started.Add(n)
+	for i := 1; i <= n; i++ {
+		notify := frame.AcquireFrame()
+		notify.Type = frame.TypeNotify
+		notify.StreamID = uint64(i)
+		notify.FrameID = uint64(i)
+		sendFrame(t, clientConn, notify)
+		frame.ReleaseFrame(notify)
+	}
+	started.Wait()
+	close(release)
+
+	got := make(map[uint64]bool)
+	_ = clientConn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	for i := 0; i < n; i++ {
+		ack := readFrame(t, reader, 4096)
+		if ack.Type != frame.TypeAgentAck {
+			frame.ReleaseFrame(ack)
+			t.Fatalf("got type %v", ack.Type)
+		}
+		got[ack.FrameID] = true
+		frame.ReleaseFrame(ack)
+	}
+	if len(got) != n {
+		t.Fatalf("got %d unique ACKs, want %d", len(got), n)
+	}
+}
+
+func TestHTTPProbeUnknownType(t *testing.T) {
+	clientConn, server := net.Pipe()
+	defer clientConn.Close()
+
+	done := make(chan struct{})
+	go func() {
+		Handle(server, func(*request.Request) {}, logger.NewNop())
+		close(done)
+	}()
+
+	if _, err := clientConn.Write([]byte("GET / HTTP/1.1\r\n\r\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not exit on HTTP probe")
+	}
+}
+
+func TestConnectAndCloseNoError(t *testing.T) {
+	clientConn, server := net.Pipe()
+
+	log := &recordingLogger{}
+	done := make(chan struct{})
+	go func() {
+		Handle(server, func(*request.Request) {}, log)
+		close(done)
+	}()
+
+	clientConn.Close()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not exit")
+	}
+
+	for _, msg := range log.messages {
+		if msg == "handle worker: %v" {
+			t.Errorf("connect-and-close should not log worker error, got %v", log.messages)
+		}
+	}
+}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -18,17 +18,45 @@ const (
 	capabilities = "pipelining,async"
 )
 
-// Handle listen connection and process frames
+// SPOP error status codes (HAProxy SPOE.txt section "Errors & timeouts")
+const (
+	statusNormal               uint32 = 0
+	statusFrameTooBig          uint32 = 3
+	statusMaxFrameSizeNotFound uint32 = 6
+	statusMaxFrameSizeInvalid  uint32 = 9
+)
+
+// Handle listens on conn and processes SPOP frames using frame.DefaultMaxFrameSize
+// as the local safety limit for the first HAPROXY-HELLO only. After HELLO, the
+// peer's max-frame-size is used for the connection
 func Handle(conn net.Conn, handler func(*request.Request), logger logger.Logger) {
+	HandleWithMaxFrameSize(conn, handler, logger, frame.DefaultMaxFrameSize)
+}
+
+// HandleWithMaxFrameSize is like Handle but uses an explicit local max-frame-size
+// for reading the first HAPROXY-HELLO. Invalid values fall back to
+// frame.DefaultMaxFrameSize
+func HandleWithMaxFrameSize(conn net.Conn, handler func(*request.Request), logger logger.Logger, maxFrameSize uint32) {
+	if maxFrameSize == 0 || frame.ValidateMaxFrameSize(maxFrameSize) != nil {
+		maxFrameSize = frame.DefaultMaxFrameSize
+	}
+
 	w := &worker{
-		conn:    conn,
-		handler: handler,
-		logger:  logger,
+		conn:              conn,
+		handler:           handler,
+		logger:            logger,
+		localMaxFrameSize: maxFrameSize,
+		maxFrameSize:      maxFrameSize,
 	}
 
 	if err := w.run(); err != nil {
 		logger.Errorf("handle worker: %v", err)
 	}
+}
+
+type writeRequest struct {
+	data []byte
+	errc chan error
 }
 
 type worker struct {
@@ -39,7 +67,13 @@ type worker struct {
 
 	logger logger.Logger
 
-	wg sync.WaitGroup
+	localMaxFrameSize uint32
+	maxFrameSize      uint32
+
+	// writeCh serializes all outbound frames on this connection so concurrent
+	// ACK goroutines cannot interleave bytes on the TCP stream
+	writeCh chan writeRequest
+	wg      sync.WaitGroup
 }
 
 func (w *worker) close() {
@@ -48,11 +82,24 @@ func (w *worker) close() {
 	}
 }
 
+func (w *worker) writeLoop(done chan struct{}) {
+	defer close(done)
+	for req := range w.writeCh {
+		req.errc <- writeFull(w.conn, req.data)
+	}
+}
+
 func (w *worker) run() error {
+	w.writeCh = make(chan writeRequest)
+	writerDone := make(chan struct{})
+	go w.writeLoop(writerDone)
 
 	defer func() {
-		// Wait for all in-flight notify handlers to finish before closing conn
+		// Wait for in-flight notify handlers (and their writes) to finish,
+		// then stop the writer before closing the connection
 		w.wg.Wait()
+		close(w.writeCh)
+		<-writerDone
 		w.close()
 	}()
 
@@ -63,24 +110,24 @@ func (w *worker) run() error {
 	for {
 		f = frame.AcquireFrame()
 
-		if err := f.Read(buf); err != nil {
+		if err := f.ReadWithLimit(buf, w.maxFrameSize); err != nil {
 			frame.ReleaseFrame(f)
 			if isConnectionClose(err) {
 				return nil
 			}
-			return fmt.Errorf("error read frame: %v", err)
+			return fmt.Errorf("error read frame: %w", err)
 		}
 
 		switch f.Type {
 		case frame.TypeHaproxyHello:
-
 			if w.ready {
+				frame.ReleaseFrame(f)
 				return fmt.Errorf("worker already ready, but got HaproxyHello frame")
 			}
 
 			if err := w.sendAgentHello(f); err != nil {
 				frame.ReleaseFrame(f)
-				return fmt.Errorf("error send AgentHello frame: %v", err)
+				return fmt.Errorf("error send AgentHello frame: %w", err)
 			}
 
 			if f.Healthcheck {
@@ -89,23 +136,26 @@ func (w *worker) run() error {
 			}
 
 			w.engineID = f.EngineID
-
 			w.ready = true
+			frame.ReleaseFrame(f)
 			continue
 
 		case frame.TypeHaproxyDisconnect:
 			if !w.ready {
+				frame.ReleaseFrame(f)
 				return fmt.Errorf("worker not ready, but got HaproxyDisconnect frame")
 			}
 
-			if err := w.sendAgentDisconnect(f, 0, "connection closed by server"); err != nil {
-				return fmt.Errorf("error send AgentDisconnect frame: %v", err)
+			if err := w.sendAgentDisconnect(0, 0, statusNormal, "connection closed by server"); err != nil {
+				frame.ReleaseFrame(f)
+				return fmt.Errorf("error send AgentDisconnect frame: %w", err)
 			}
 			frame.ReleaseFrame(f)
 			return nil
 
 		case frame.TypeNotify:
 			if !w.ready {
+				frame.ReleaseFrame(f)
 				return fmt.Errorf("worker not ready, but got Notify frame")
 			}
 
@@ -113,7 +163,12 @@ func (w *worker) run() error {
 			go w.processNotifyFrame(f)
 
 		default:
-			w.logger.Errorf("unexpected frame type: %v", f.Type)
+			ft := f.Type
+			frame.ReleaseFrame(f)
+			if !w.ready {
+				return fmt.Errorf("unexpected frame type before handshake: %v", ft)
+			}
+			w.logger.Errorf("unexpected frame type: %v", ft)
 		}
 	}
 }

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -82,24 +82,32 @@ func TestWorkerConcurrent(t *testing.T) {
 		Handle(server2, m.Handle, logger.NewNop())
 	}()
 	duration := time.Second
+	errCh := make(chan error, 2)
 	loop := func(s client.Client) {
-		if s.Init() != nil {
-			t.Fatal("unexpected error on Init")
+		if err := s.Init(); err != nil {
+			errCh <- err
+			return
 		}
+		deadline := time.After(duration)
 		for {
 			select {
-			case <-time.After(duration):
-				s.Stop()
+			case <-deadline:
+				_ = s.Stop()
+				errCh <- nil
+				return
 			default:
-				s.Notify()
+				_ = s.Notify()
 			}
 		}
 	}
 	go loop(spoe)
 	go loop(spoe2)
 
-	// Let's wait a bit to have everything finished
-	<-time.After(duration)
+	for i := 0; i < 2; i++ {
+		if err := <-errCh; err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
 }
 
 /*
@@ -175,8 +183,9 @@ func TestWorkerNotifyInFlightOnDisconnect(t *testing.T) {
 	frame.ReleaseFrame(hello)
 
 	resp := frame.AcquireFrame()
-	// frame.Read does not parse AgentHello payload and returns an error; ignore it.
-	_ = resp.Read(reader)
+	if err := resp.ReadWithLimit(reader, 16*1024); err != nil {
+		t.Fatalf("read AgentHello: %v", err)
+	}
 	if resp.Type != frame.TypeAgentHello {
 		t.Fatalf("unexpected response type: got %v, want AgentHello", resp.Type)
 	}
@@ -207,8 +216,10 @@ func TestWorkerNotifyInFlightOnDisconnect(t *testing.T) {
 	_ = clientConn.SetReadDeadline(time.Now().Add(2 * time.Second))
 	for i := 0; i < 2; i++ {
 		f := frame.AcquireFrame()
-		// Ignore errors: frame.Read returns an error for Agent* frames after consuming the payload.
-		_ = f.Read(reader)
+		if err := f.ReadWithLimit(reader, 16*1024); err != nil {
+			frame.ReleaseFrame(f)
+			break
+		}
 		switch f.Type {
 		case frame.TypeAgentAck:
 			gotAck = true


### PR DESCRIPTION
reject oversized, zero, and truncated frames before allocation so a crafted known frame type cannot OOM the agent. Use a local MaxFrameSize only for the first HAPROXY-HELLO, then apply HAProxy's announced limit. Also harden message/KV/typed-data parsing, serialize connection writes, and add regression plus fuzz coverage